### PR TITLE
docs: record mutation auth audit closeout

### DIFF
--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -2,7 +2,7 @@
 
 _Generated file. Regenerate with `python scripts/generate_heartbeat.py`._
 
-_Generated: 2026-03-27T22:14:42.570314+00:00_
+_Generated: 2026-03-27T22:28:42.948435+00:00_
 
 ## Current status
 - Purpose: Exa-powered insurance intelligence toolkit for CAT-loss, claims, expert, contractor, and market/regulatory research workflows.
@@ -59,20 +59,21 @@ _Generated: 2026-03-27T22:14:42.570314+00:00_
 - Scope beyond this scaffold into auth redesign, persistence implementation, async jobs, deployment, infra, or broader docs refactors.
 
 ## Last session
-- Date: 2026-03-27e
-- Objective: Add a tracked `.github/PULL_REQUEST_TEMPLATE.md` for thin-slice review consistency.
+- Date: 2026-03-27f
+- Objective: Inspect one single-record mutation route involving user-owned data and patch at most one confirmed auth gap.
 - Changes made:
-  - Confirmed `.github/` already exists and that no PR template existed anywhere relevant in the repo.
-  - Read `AGENTS.md` so the new template would complement the root agent guidance instead of duplicating it.
-  - Added `.github/PULL_REQUEST_TEMPLATE.md` with concise sections for summary, scope boundary, validation, risks/follow-ups, and a conditional single-record auth checklist.
-  - Added a focused session log for this docs/process slice.
+  - Inventoried the mutation routes in `src/exa_demo/api.py`.
+  - Chose `DELETE /api/me/saved-queries/{query_id}` as the clearest single-record user-owned mutation boundary.
+  - Inspected the route in `src/exa_demo/api.py`, the scoped delete implementation in `src/exa_demo/persistence.py`, and the adjacent saved-query auth tests in `tests/test_users.py`.
+  - Confirmed the route already enforces owner-only deletion by passing the current `user_id` into a repository delete scoped by both `query_id` and `user_id`.
+  - Added a focused no-gap session log for this mutation auth audit.
 - Validation:
-  - Verified the final PR template content and section coverage.
-  - Regenerated `HEARTBEAT.md` and `heartbeat.json`.
+  - Ran `python -m pytest tests/test_users.py -q -k "delete_saved_query or delete_not_found or user_cannot_delete_others_query or delete_wrong_user"` and confirmed `4 passed, 20 deselected`.
 - Open issues:
-  - The template stays intentionally small, so reviewers still need to exercise judgment on broader architectural or rollout risks not covered by the checklist.
+  - No confirmed auth gap remains for the inspected saved-query deletion boundary.
+  - This slice intentionally did not audit any additional mutation routes.
 - Decisions proposed:
-  - Keep the PR template checklist-style and complementary to `AGENTS.md` rather than turning it into a second long-form process guide.
+  - Close this slice without product-code changes because the inspected mutation boundary already has correct owner scoping and adjacent coverage.
 
 ## Next thin slice
-- If later needed, add one tiny contributor-facing note in README pointing maintainers to `AGENTS.md` and the PR template.
+- Inspect one other single-record mutation route only if a clearly user-owned ID-based mutation endpoint is added or identified.

--- a/docs/sessions/2026-03-27-mutation-auth-audit-saved-query-delete.md
+++ b/docs/sessions/2026-03-27-mutation-auth-audit-saved-query-delete.md
@@ -1,0 +1,37 @@
+# Session: Mutation Auth Audit - Saved Query Delete
+
+- Date: 2026-03-27
+- Participants: Codex (GPT-5)
+- Related scope: single-record mutation auth boundary
+
+## Context
+
+Inspect exactly one single-record mutation route involving user-owned data and patch at most one confirmed auth gap.
+
+## Route Inspected
+
+- `DELETE /api/me/saved-queries/{query_id}`
+
+## Findings
+
+- The route resolves the current user with `get_current_user(request)`.
+- The route delegates deletion to `run_repo.delete_saved_query(query_id, uid)`.
+- The repository delete is explicitly scoped by both query id and user id: `DELETE FROM saved_queries WHERE id = ? AND user_id = ?`.
+- Existing tests already cover:
+  - owner can delete own saved query
+  - deleting a missing saved query returns `404`
+  - a different user cannot delete another user's saved query
+  - repository-level wrong-user delete returns `False`
+
+## Decision
+
+- No confirmed auth gap remains for this inspected mutation boundary.
+- Per the slice rules, stop without editing API/auth code.
+
+## Validation
+
+- `python -m pytest tests/test_users.py -q -k "delete_saved_query or delete_not_found or user_cannot_delete_others_query or delete_wrong_user"` -> passed (`4 passed, 20 deselected`)
+
+## Recommended Next Task
+
+- Audit one other single-record mutation boundary only if it is clearly user-owned and ID-addressable, for example a future job cancel/delete or record rerun endpoint if one is added.

--- a/heartbeat.json
+++ b/heartbeat.json
@@ -1,6 +1,6 @@
 {
   "repo": "exai-insurance-intel",
-  "generated_at": "2026-03-27T22:14:42.570314+00:00",
+  "generated_at": "2026-03-27T22:28:42.948435+00:00",
   "purpose": "Exa-powered insurance intelligence toolkit for CAT-loss, claims, expert, contractor, and market/regulatory research workflows.",
   "strategic_role": "Workflow engine plus controlled pilot web-product base for internal insurance-intelligence validation.",
   "current_milestone": "Phase 5 Level 1 is partially complete: the thin FastAPI wrapper and frontend shell are shipped, while pilot auth/request controls and persistence baseline remain the next bounded slices.",
@@ -51,29 +51,30 @@
   ],
   "update_policy": "`MEMORY.md` stays curated and human-reviewed. `memory/YYYY-MM-DD.md` stays append-only. `HEARTBEAT.md` and `heartbeat.json` are reproducible generated outputs and are never the durable source of truth.",
   "last_session": {
-    "date": "2026-03-27e",
-    "objective": "Add a tracked `.github/PULL_REQUEST_TEMPLATE.md` for thin-slice review consistency.",
+    "date": "2026-03-27f",
+    "objective": "Inspect one single-record mutation route involving user-owned data and patch at most one confirmed auth gap.",
     "changes_made": [
-      "Confirmed `.github/` already exists and that no PR template existed anywhere relevant in the repo.",
-      "Read `AGENTS.md` so the new template would complement the root agent guidance instead of duplicating it.",
-      "Added `.github/PULL_REQUEST_TEMPLATE.md` with concise sections for summary, scope boundary, validation, risks/follow-ups, and a conditional single-record auth checklist.",
-      "Added a focused session log for this docs/process slice."
+      "Inventoried the mutation routes in `src/exa_demo/api.py`.",
+      "Chose `DELETE /api/me/saved-queries/{query_id}` as the clearest single-record user-owned mutation boundary.",
+      "Inspected the route in `src/exa_demo/api.py`, the scoped delete implementation in `src/exa_demo/persistence.py`, and the adjacent saved-query auth tests in `tests/test_users.py`.",
+      "Confirmed the route already enforces owner-only deletion by passing the current `user_id` into a repository delete scoped by both `query_id` and `user_id`.",
+      "Added a focused no-gap session log for this mutation auth audit."
     ],
     "validation_run": [
-      "Verified the final PR template content and section coverage.",
-      "Regenerated `HEARTBEAT.md` and `heartbeat.json`."
+      "Ran `python -m pytest tests/test_users.py -q -k \"delete_saved_query or delete_not_found or user_cannot_delete_others_query or delete_wrong_user\"` and confirmed `4 passed, 20 deselected`."
     ],
     "open_issues": [
-      "The template stays intentionally small, so reviewers still need to exercise judgment on broader architectural or rollout risks not covered by the checklist."
+      "No confirmed auth gap remains for the inspected saved-query deletion boundary.",
+      "This slice intentionally did not audit any additional mutation routes."
     ],
     "decisions_proposed": [
-      "Keep the PR template checklist-style and complementary to `AGENTS.md` rather than turning it into a second long-form process guide."
+      "Close this slice without product-code changes because the inspected mutation boundary already has correct owner scoping and adjacent coverage."
     ],
     "next_thin_slice": [
-      "If later needed, add one tiny contributor-facing note in README pointing maintainers to `AGENTS.md` and the PR template."
+      "Inspect one other single-record mutation route only if a clearly user-owned ID-based mutation endpoint is added or identified."
     ]
   },
   "next_thin_slice": [
-    "If later needed, add one tiny contributor-facing note in README pointing maintainers to `AGENTS.md` and the PR template."
+    "Inspect one other single-record mutation route only if a clearly user-owned ID-based mutation endpoint is added or identified."
   ]
 }

--- a/memory/2026-03-27f.md
+++ b/memory/2026-03-27f.md
@@ -1,0 +1,24 @@
+# Session Memory
+
+## Objective
+Inspect one single-record mutation route involving user-owned data and patch at most one confirmed auth gap.
+
+## Changes made
+- Inventoried the mutation routes in `src/exa_demo/api.py`.
+- Chose `DELETE /api/me/saved-queries/{query_id}` as the clearest single-record user-owned mutation boundary.
+- Inspected the route in `src/exa_demo/api.py`, the scoped delete implementation in `src/exa_demo/persistence.py`, and the adjacent saved-query auth tests in `tests/test_users.py`.
+- Confirmed the route already enforces owner-only deletion by passing the current `user_id` into a repository delete scoped by both `query_id` and `user_id`.
+- Added a focused no-gap session log for this mutation auth audit.
+
+## Validation run
+- Ran `python -m pytest tests/test_users.py -q -k "delete_saved_query or delete_not_found or user_cannot_delete_others_query or delete_wrong_user"` and confirmed `4 passed, 20 deselected`.
+
+## Open issues
+- No confirmed auth gap remains for the inspected saved-query deletion boundary.
+- This slice intentionally did not audit any additional mutation routes.
+
+## Decisions proposed
+- Close this slice without product-code changes because the inspected mutation boundary already has correct owner scoping and adjacent coverage.
+
+## Next thin slice
+- Inspect one other single-record mutation route only if a clearly user-owned ID-based mutation endpoint is added or identified.


### PR DESCRIPTION
## Summary
- Audit one single-record mutation route involving user-owned data.
- Record an evidence-backed no-gap closeout for the saved-query delete boundary.
- Regenerate heartbeat from the new session-memory entry.

## Files changed
- `docs/sessions/2026-03-27-mutation-auth-audit-saved-query-delete.md`
- `memory/2026-03-27f.md`
- `HEARTBEAT.md`
- `heartbeat.json`

## Validation
- `python -m pytest tests/test_users.py -q -k "delete_saved_query or delete_not_found or user_cannot_delete_others_query or delete_wrong_user"` -> `4 passed, 20 deselected`
- Confirmed the route scopes deletion by `query_id` and current `user_id`.

## Why this slice matters
- It closes one mutation-boundary audit with concrete evidence while keeping scope to a single user-owned ID-based route.
