### PR TITLE
docs: record collection auth audit closeout

### DIFF
--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -2,7 +2,7 @@
 
 _Generated file. Regenerate with `python scripts/generate_heartbeat.py`._
 
-_Generated: 2026-03-27T22:28:42.948435+00:00_
+_Generated: 2026-03-27T22:46:51.963062+00:00_
 
 ## Current status
 - Purpose: Exa-powered insurance intelligence toolkit for CAT-loss, claims, expert, contractor, and market/regulatory research workflows.
@@ -59,21 +59,21 @@ _Generated: 2026-03-27T22:28:42.948435+00:00_
 - Scope beyond this scaffold into auth redesign, persistence implementation, async jobs, deployment, infra, or broader docs refactors.
 
 ## Last session
-- Date: 2026-03-27f
-- Objective: Inspect one single-record mutation route involving user-owned data and patch at most one confirmed auth gap.
+- Date: 2026-03-27g
+- Objective: Inspect one collection/list auth boundary involving user-owned data and patch at most one confirmed gap.
 - Changes made:
-  - Inventoried the mutation routes in `src/exa_demo/api.py`.
-  - Chose `DELETE /api/me/saved-queries/{query_id}` as the clearest single-record user-owned mutation boundary.
-  - Inspected the route in `src/exa_demo/api.py`, the scoped delete implementation in `src/exa_demo/persistence.py`, and the adjacent saved-query auth tests in `tests/test_users.py`.
-  - Confirmed the route already enforces owner-only deletion by passing the current `user_id` into a repository delete scoped by both `query_id` and `user_id`.
-  - Added a focused no-gap session log for this mutation auth audit.
+  - Inventoried the collection/list routes in `src/exa_demo/api.py`.
+  - Chose `GET /api/runs` because it exists and is the highest-risk non-`/me` collection route in the current branch state.
+  - Inspected the route in `src/exa_demo/api.py`, the underlying `list_runs(...)` repository call in `src/exa_demo/persistence.py`, the ops gate in `src/exa_demo/api_auth.py`, and the adjacent `/api/runs` auth tests in `tests/test_users.py`.
+  - Confirmed the route already enforces ops-only access before the unscoped repository query can return cross-user run records.
+  - Added a focused no-gap session log for this collection auth audit.
 - Validation:
-  - Ran `python -m pytest tests/test_users.py -q -k "delete_saved_query or delete_not_found or user_cannot_delete_others_query or delete_wrong_user"` and confirmed `4 passed, 20 deselected`.
+  - Ran `python -m pytest tests/test_users.py -q -k "allowlisted_ops_user_sees_all_runs or non_ops_user_cannot_access_global_runs"` and confirmed `2 passed, 22 deselected`.
 - Open issues:
-  - No confirmed auth gap remains for the inspected saved-query deletion boundary.
-  - This slice intentionally did not audit any additional mutation routes.
+  - No confirmed auth gap remains for the inspected `GET /api/runs` boundary.
+  - This slice intentionally did not audit any additional collection routes.
 - Decisions proposed:
-  - Close this slice without product-code changes because the inspected mutation boundary already has correct owner scoping and adjacent coverage.
+  - Close this slice without product-code changes because the inspected collection boundary is already correctly ops-gated.
 
 ## Next thin slice
-- Inspect one other single-record mutation route only if a clearly user-owned ID-based mutation endpoint is added or identified.
+- Inspect one other collection/list route only if it is not `/me/...` scoped, not obviously ops-only, and can expose user-owned data across accounts.

--- a/docs/sessions/2026-03-27-collection-auth-audit-runs-no-gap.md
+++ b/docs/sessions/2026-03-27-collection-auth-audit-runs-no-gap.md
@@ -1,0 +1,38 @@
+# Session: Collection Auth Audit (`GET /api/runs`) No-Gap Closeout
+
+- Date: 2026-03-27
+- Participants: Codex (GPT-5)
+- Related scope: collection/list auth boundary for persisted run history
+
+## Context
+
+Inspect exactly one collection/list auth boundary that could expose user-owned data across accounts and patch at most one confirmed gap.
+
+## Inspection Targets
+
+- `src/exa_demo/api.py`: `api_list_runs`
+- `src/exa_demo/persistence.py`: `list_runs`
+- `src/exa_demo/api_auth.py`: `require_ops_access`
+- `tests/test_users.py`: adjacent `/api/runs` auth coverage
+
+## Findings
+
+- `GET /api/runs` exists and is the highest-risk collection route because it returns persisted run history that is not `/me/...` scoped.
+- `api_list_runs` calls `require_ops_access(request)` before invoking `run_repo.list_runs(...)`.
+- The repository `list_runs(...)` call itself is intentionally unscoped for this route and can return cross-user data, but only after the route-level ops gate passes.
+- Adjacent auth tests already prove the intended boundary:
+  - allowlisted ops user can read the global `/api/runs` collection
+  - non-ops user receives `403` on `/api/runs`
+
+## Decision
+
+- No confirmed auth gap remains for the inspected `GET /api/runs` boundary in the current branch state.
+- Stop without editing API, auth, or persistence code.
+
+## Validation
+
+- `python -m pytest tests/test_users.py -q -k "allowlisted_ops_user_sees_all_runs or non_ops_user_cannot_access_global_runs"` -> passed (`2 passed, 22 deselected`)
+
+## Recommended Next Task
+
+- Inspect exactly one other non-`/me` collection boundary only if it currently returns user-owned data and is not already obviously ops-only.

--- a/heartbeat.json
+++ b/heartbeat.json
@@ -1,6 +1,6 @@
 {
   "repo": "exai-insurance-intel",
-  "generated_at": "2026-03-27T22:28:42.948435+00:00",
+  "generated_at": "2026-03-27T22:46:51.963062+00:00",
   "purpose": "Exa-powered insurance intelligence toolkit for CAT-loss, claims, expert, contractor, and market/regulatory research workflows.",
   "strategic_role": "Workflow engine plus controlled pilot web-product base for internal insurance-intelligence validation.",
   "current_milestone": "Phase 5 Level 1 is partially complete: the thin FastAPI wrapper and frontend shell are shipped, while pilot auth/request controls and persistence baseline remain the next bounded slices.",
@@ -51,30 +51,30 @@
   ],
   "update_policy": "`MEMORY.md` stays curated and human-reviewed. `memory/YYYY-MM-DD.md` stays append-only. `HEARTBEAT.md` and `heartbeat.json` are reproducible generated outputs and are never the durable source of truth.",
   "last_session": {
-    "date": "2026-03-27f",
-    "objective": "Inspect one single-record mutation route involving user-owned data and patch at most one confirmed auth gap.",
+    "date": "2026-03-27g",
+    "objective": "Inspect one collection/list auth boundary involving user-owned data and patch at most one confirmed gap.",
     "changes_made": [
-      "Inventoried the mutation routes in `src/exa_demo/api.py`.",
-      "Chose `DELETE /api/me/saved-queries/{query_id}` as the clearest single-record user-owned mutation boundary.",
-      "Inspected the route in `src/exa_demo/api.py`, the scoped delete implementation in `src/exa_demo/persistence.py`, and the adjacent saved-query auth tests in `tests/test_users.py`.",
-      "Confirmed the route already enforces owner-only deletion by passing the current `user_id` into a repository delete scoped by both `query_id` and `user_id`.",
-      "Added a focused no-gap session log for this mutation auth audit."
+      "Inventoried the collection/list routes in `src/exa_demo/api.py`.",
+      "Chose `GET /api/runs` because it exists and is the highest-risk non-`/me` collection route in the current branch state.",
+      "Inspected the route in `src/exa_demo/api.py`, the underlying `list_runs(...)` repository call in `src/exa_demo/persistence.py`, the ops gate in `src/exa_demo/api_auth.py`, and the adjacent `/api/runs` auth tests in `tests/test_users.py`.",
+      "Confirmed the route already enforces ops-only access before the unscoped repository query can return cross-user run records.",
+      "Added a focused no-gap session log for this collection auth audit."
     ],
     "validation_run": [
-      "Ran `python -m pytest tests/test_users.py -q -k \"delete_saved_query or delete_not_found or user_cannot_delete_others_query or delete_wrong_user\"` and confirmed `4 passed, 20 deselected`."
+      "Ran `python -m pytest tests/test_users.py -q -k \"allowlisted_ops_user_sees_all_runs or non_ops_user_cannot_access_global_runs\"` and confirmed `2 passed, 22 deselected`."
     ],
     "open_issues": [
-      "No confirmed auth gap remains for the inspected saved-query deletion boundary.",
-      "This slice intentionally did not audit any additional mutation routes."
+      "No confirmed auth gap remains for the inspected `GET /api/runs` boundary.",
+      "This slice intentionally did not audit any additional collection routes."
     ],
     "decisions_proposed": [
-      "Close this slice without product-code changes because the inspected mutation boundary already has correct owner scoping and adjacent coverage."
+      "Close this slice without product-code changes because the inspected collection boundary is already correctly ops-gated."
     ],
     "next_thin_slice": [
-      "Inspect one other single-record mutation route only if a clearly user-owned ID-based mutation endpoint is added or identified."
+      "Inspect one other collection/list route only if it is not `/me/...` scoped, not obviously ops-only, and can expose user-owned data across accounts."
     ]
   },
   "next_thin_slice": [
-    "Inspect one other single-record mutation route only if a clearly user-owned ID-based mutation endpoint is added or identified."
+    "Inspect one other collection/list route only if it is not `/me/...` scoped, not obviously ops-only, and can expose user-owned data across accounts."
   ]
 }

--- a/memory/2026-03-27g.md
+++ b/memory/2026-03-27g.md
@@ -1,0 +1,24 @@
+# Session Memory
+
+## Objective
+Inspect one collection/list auth boundary involving user-owned data and patch at most one confirmed gap.
+
+## Changes made
+- Inventoried the collection/list routes in `src/exa_demo/api.py`.
+- Chose `GET /api/runs` because it exists and is the highest-risk non-`/me` collection route in the current branch state.
+- Inspected the route in `src/exa_demo/api.py`, the underlying `list_runs(...)` repository call in `src/exa_demo/persistence.py`, the ops gate in `src/exa_demo/api_auth.py`, and the adjacent `/api/runs` auth tests in `tests/test_users.py`.
+- Confirmed the route already enforces ops-only access before the unscoped repository query can return cross-user run records.
+- Added a focused no-gap session log for this collection auth audit.
+
+## Validation run
+- Ran `python -m pytest tests/test_users.py -q -k "allowlisted_ops_user_sees_all_runs or non_ops_user_cannot_access_global_runs"` and confirmed `2 passed, 22 deselected`.
+
+## Open issues
+- No confirmed auth gap remains for the inspected `GET /api/runs` boundary.
+- This slice intentionally did not audit any additional collection routes.
+
+## Decisions proposed
+- Close this slice without product-code changes because the inspected collection boundary is already correctly ops-gated.
+
+## Next thin slice
+- Inspect one other collection/list route only if it is not `/me/...` scoped, not obviously ops-only, and can expose user-owned data across accounts.


### PR DESCRIPTION
## Summary
Record an evidence-backed no-gap closeout for one collection/list auth boundary.

## Route inspected
- `GET /api/runs`

## What was found
- The route is already gated by `require_ops_access(request)`.
- The repo list call is intentionally unscoped because the route is ops-only.
- Existing narrow tests already prove ops allow and non-ops deny.
- No product-code or auth-code change was needed.

## Files changed
- `docs/sessions/2026-03-27-collection-auth-audit-runs-no-gap.md`
- `memory/2026-03-27g.md`
- `HEARTBEAT.md`
- `heartbeat.json`

## Validation
- `python -m pytest tests/test_users.py -q -k "allowlisted_ops_user_sees_all_runs or non_ops_user_cannot_access_global_runs"` -> `2 passed, 22 deselected`

## Why no code change was needed
This route was already correctly scoped in the current repo state, so this slice closes as a narrow no-gap audit.
