### PR TITLE
feat: circuit breaker with retry/backoff for Exa API

### DIFF
--- a/src/exa_demo/__init__.py
+++ b/src/exa_demo/__init__.py
@@ -1,6 +1,7 @@
 ﻿from .artifacts import ExperimentArtifactWriter
 from .cache import SqliteCacheStore, request_hash_for_payload
-from .client import ExaCallMeta, build_exa_payload, exa_search_people
+from .client import ExaCallMeta, build_exa_payload, exa_circuit_breaker, exa_search_people
+from .resilience import CircuitBreaker, CircuitOpenError
 from .config import RuntimeState, default_config, default_pricing, load_runtime_state
 from .evaluation import (
     DEFAULT_RELEVANCE_KEYWORDS,
@@ -21,6 +22,8 @@ from .reporting import (
 from .safety import extract_preview, redact_response, redact_text
 
 __all__ = [
+    "CircuitBreaker",
+    "CircuitOpenError",
     "CostBreakdown",
     "DEFAULT_RELEVANCE_KEYWORDS",
     "ExaCallMeta",
@@ -38,6 +41,7 @@ __all__ = [
     "default_pricing",
     "evaluate_batch_queries",
     "evaluate_result_set",
+    "exa_circuit_breaker",
     "exa_search_people",
     "extract_preview",
     "load_benchmark_queries",

--- a/src/exa_demo/client.py
+++ b/src/exa_demo/client.py
@@ -22,7 +22,11 @@ from .client_smoke import (
     mock_exa_structured_search_response,
 )
 from .cost_model import estimate_cost_from_pricing
+from .resilience import CircuitBreaker
 from .safety import redact_response
+
+# Module-level circuit breaker shared across all Exa API calls.
+exa_circuit_breaker = CircuitBreaker()
 
 
 @dataclass
@@ -60,15 +64,18 @@ def exa_http_call(
     if not exa_api_key:
         raise RuntimeError("Missing EXA_API_KEY for live Exa request.")
 
-    headers = {"x-api-key": exa_api_key, "Content-Type": "application/json"}
-    response = requests.post(
-        _resolve_exa_endpoint(str(config["exa_endpoint"]), endpoint_name=endpoint_name),
-        headers=headers,
-        json=payload,
-        timeout=timeout,
-    )
-    response.raise_for_status()
-    return response.json()
+    def _do_request() -> Dict[str, Any]:
+        headers = {"x-api-key": exa_api_key, "Content-Type": "application/json"}
+        response = requests.post(
+            _resolve_exa_endpoint(str(config["exa_endpoint"]), endpoint_name=endpoint_name),
+            headers=headers,
+            json=payload,
+            timeout=timeout,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    return exa_circuit_breaker.call(_do_request)
 
 
 def exa_search_people(

--- a/src/exa_demo/resilience.py
+++ b/src/exa_demo/resilience.py
@@ -1,0 +1,195 @@
+"""Circuit breaker and retry logic for external API calls."""
+
+from __future__ import annotations
+
+import logging
+import random
+import threading
+import time
+from typing import TypeVar
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+# Exceptions considered transient and eligible for retry / circuit-breaker tracking.
+_TRANSIENT_HTTP_CODES = frozenset({429, 500, 502, 503, 504})
+
+
+def is_transient(exc: BaseException) -> bool:
+    """Return True if *exc* looks like a transient network/server error."""
+    if isinstance(exc, requests.exceptions.ConnectionError):
+        return True
+    if isinstance(exc, requests.exceptions.Timeout):
+        return True
+    if isinstance(exc, requests.exceptions.HTTPError):
+        resp = exc.response
+        if resp is not None and resp.status_code in _TRANSIENT_HTTP_CODES:
+            return True
+    return False
+
+
+class CircuitOpenError(RuntimeError):
+    """Raised when a call is rejected because the circuit breaker is open."""
+
+    def __init__(self, reset_at: float) -> None:
+        remaining = max(0.0, reset_at - time.monotonic())
+        super().__init__(
+            f"Circuit breaker is open. Retry after {remaining:.1f}s."
+        )
+        self.reset_at = reset_at
+
+
+class CircuitBreaker:
+    """Lightweight circuit breaker with exponential-backoff retry.
+
+    States
+    ------
+    CLOSED   – requests flow normally; consecutive failures are counted.
+    OPEN     – requests are rejected immediately (raises ``CircuitOpenError``).
+    HALF-OPEN – one probe request is allowed through to test recovery.
+
+    Parameters
+    ----------
+    failure_threshold : int
+        Consecutive transient failures before the breaker trips open.
+    recovery_timeout : float
+        Seconds to wait in OPEN state before allowing a probe (half-open).
+    max_retries : int
+        How many times to retry a transient failure *before* counting it as
+        a circuit-breaker failure.  Set to 0 to disable retry.
+    backoff_base : float
+        Base delay (seconds) for exponential backoff between retries.
+    backoff_max : float
+        Maximum delay (seconds) between retries.
+    """
+
+    CLOSED = "closed"
+    OPEN = "open"
+    HALF_OPEN = "half_open"
+
+    def __init__(
+        self,
+        *,
+        failure_threshold: int = 5,
+        recovery_timeout: float = 30.0,
+        max_retries: int = 2,
+        backoff_base: float = 0.5,
+        backoff_max: float = 10.0,
+    ) -> None:
+        self.failure_threshold = failure_threshold
+        self.recovery_timeout = recovery_timeout
+        self.max_retries = max_retries
+        self.backoff_base = backoff_base
+        self.backoff_max = backoff_max
+
+        self._lock = threading.Lock()
+        self._state = self.CLOSED
+        self._consecutive_failures = 0
+        self._opened_at: float = 0.0
+
+    # -- public API ----------------------------------------------------------
+
+    @property
+    def state(self) -> str:
+        with self._lock:
+            return self._current_state()
+
+    def call(self, fn, *args, **kwargs):
+        """Invoke *fn* with circuit-breaker protection and retry.
+
+        Returns the result of *fn(*args, **kwargs)* on success.
+        Raises ``CircuitOpenError`` if the breaker is open.
+        Re-raises the original exception if all retries are exhausted.
+        """
+        self._check_state()
+
+        last_exc: BaseException | None = None
+        attempts = 1 + self.max_retries  # first try + retries
+
+        for attempt in range(attempts):
+            try:
+                result = fn(*args, **kwargs)
+                self._record_success()
+                return result
+            except Exception as exc:
+                last_exc = exc
+                if not is_transient(exc):
+                    # Non-transient errors (4xx, auth, etc.) skip retry.
+                    self._record_failure()
+                    raise
+
+                if attempt < attempts - 1:
+                    delay = self._backoff_delay(attempt)
+                    logger.warning(
+                        "Transient error (attempt %d/%d), retrying in %.2fs: %s",
+                        attempt + 1,
+                        attempts,
+                        delay,
+                        exc,
+                    )
+                    time.sleep(delay)
+                else:
+                    logger.error(
+                        "All %d attempts exhausted: %s", attempts, exc
+                    )
+                    self._record_failure()
+                    raise
+
+        # Should not reach here, but satisfy type checker.
+        raise last_exc  # type: ignore[misc]
+
+    def reset(self) -> None:
+        """Manually reset the breaker to closed state."""
+        with self._lock:
+            self._state = self.CLOSED
+            self._consecutive_failures = 0
+            self._opened_at = 0.0
+
+    # -- internals -----------------------------------------------------------
+
+    def _current_state(self) -> str:
+        """Return effective state, promoting OPEN → HALF_OPEN when timeout expires."""
+        if self._state == self.OPEN:
+            if time.monotonic() >= self._opened_at + self.recovery_timeout:
+                self._state = self.HALF_OPEN
+        return self._state
+
+    def _check_state(self) -> None:
+        with self._lock:
+            state = self._current_state()
+            if state == self.OPEN:
+                raise CircuitOpenError(
+                    self._opened_at + self.recovery_timeout
+                )
+            # CLOSED and HALF_OPEN both allow the call through.
+
+    def _record_success(self) -> None:
+        with self._lock:
+            self._consecutive_failures = 0
+            if self._state == self.HALF_OPEN:
+                logger.info("Circuit breaker closing after successful probe.")
+                self._state = self.CLOSED
+
+    def _record_failure(self) -> None:
+        with self._lock:
+            self._consecutive_failures += 1
+            if self._state == self.HALF_OPEN:
+                # Probe failed → reopen immediately.
+                logger.warning("Half-open probe failed, re-opening circuit.")
+                self._state = self.OPEN
+                self._opened_at = time.monotonic()
+            elif self._consecutive_failures >= self.failure_threshold:
+                logger.warning(
+                    "Circuit breaker tripping open after %d consecutive failures.",
+                    self._consecutive_failures,
+                )
+                self._state = self.OPEN
+                self._opened_at = time.monotonic()
+
+    def _backoff_delay(self, attempt: int) -> float:
+        """Exponential backoff with full jitter."""
+        delay = min(self.backoff_base * (2 ** attempt), self.backoff_max)
+        return random.uniform(0, delay)

--- a/tests/test_resilience.py
+++ b/tests/test_resilience.py
@@ -1,0 +1,279 @@
+"""Tests for circuit breaker and retry logic."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+import requests
+
+from exa_demo.resilience import CircuitBreaker, CircuitOpenError, is_transient
+
+
+# ---------------------------------------------------------------------------
+# is_transient
+# ---------------------------------------------------------------------------
+
+
+def test_is_transient_connection_error() -> None:
+    assert is_transient(requests.exceptions.ConnectionError()) is True
+
+
+def test_is_transient_timeout() -> None:
+    assert is_transient(requests.exceptions.Timeout()) is True
+
+
+def test_is_transient_500() -> None:
+    resp = MagicMock()
+    resp.status_code = 502
+    exc = requests.exceptions.HTTPError(response=resp)
+    assert is_transient(exc) is True
+
+
+def test_is_transient_400_not_transient() -> None:
+    resp = MagicMock()
+    resp.status_code = 400
+    exc = requests.exceptions.HTTPError(response=resp)
+    assert is_transient(exc) is False
+
+
+def test_is_transient_runtime_error_not_transient() -> None:
+    assert is_transient(RuntimeError("bad")) is False
+
+
+# ---------------------------------------------------------------------------
+# CircuitBreaker: basic success
+# ---------------------------------------------------------------------------
+
+
+def test_call_success_returns_result() -> None:
+    cb = CircuitBreaker(failure_threshold=3, max_retries=0)
+    result = cb.call(lambda: 42)
+    assert result == 42
+    assert cb.state == CircuitBreaker.CLOSED
+
+
+def test_call_passes_args_and_kwargs() -> None:
+    cb = CircuitBreaker(max_retries=0)
+    result = cb.call(lambda a, b=0: a + b, 10, b=5)
+    assert result == 15
+
+
+# ---------------------------------------------------------------------------
+# CircuitBreaker: retry on transient errors
+# ---------------------------------------------------------------------------
+
+
+def test_retry_on_transient_then_succeed() -> None:
+    call_count = 0
+
+    def flaky():
+        nonlocal call_count
+        call_count += 1
+        if call_count < 3:
+            raise requests.exceptions.ConnectionError("conn refused")
+        return "ok"
+
+    cb = CircuitBreaker(
+        failure_threshold=5,
+        max_retries=2,
+        backoff_base=0.01,  # fast for tests
+        backoff_max=0.02,
+    )
+    result = cb.call(flaky)
+    assert result == "ok"
+    assert call_count == 3
+    assert cb.state == CircuitBreaker.CLOSED
+
+
+def test_retry_exhausted_raises_and_counts_failure() -> None:
+    cb = CircuitBreaker(
+        failure_threshold=5,
+        max_retries=1,
+        backoff_base=0.01,
+    )
+    try:
+        cb.call(_raise_connection_error)
+        assert False, "Should have raised"
+    except requests.exceptions.ConnectionError:
+        pass
+    # Should have counted one failure toward the breaker.
+    assert cb._consecutive_failures == 1
+    assert cb.state == CircuitBreaker.CLOSED
+
+
+# ---------------------------------------------------------------------------
+# CircuitBreaker: non-transient errors skip retry
+# ---------------------------------------------------------------------------
+
+
+def test_non_transient_error_not_retried() -> None:
+    call_count = 0
+
+    def bad_request():
+        nonlocal call_count
+        call_count += 1
+        resp = MagicMock()
+        resp.status_code = 400
+        raise requests.exceptions.HTTPError(response=resp)
+
+    cb = CircuitBreaker(failure_threshold=5, max_retries=3, backoff_base=0.01)
+    try:
+        cb.call(bad_request)
+        assert False, "Should have raised"
+    except requests.exceptions.HTTPError:
+        pass
+    assert call_count == 1  # no retry
+
+
+# ---------------------------------------------------------------------------
+# CircuitBreaker: trip open
+# ---------------------------------------------------------------------------
+
+
+def test_trips_open_after_threshold() -> None:
+    cb = CircuitBreaker(failure_threshold=3, max_retries=0, recovery_timeout=60.0)
+
+    for _ in range(3):
+        try:
+            cb.call(_raise_connection_error)
+        except requests.exceptions.ConnectionError:
+            pass
+
+    assert cb.state == CircuitBreaker.OPEN
+
+    try:
+        cb.call(lambda: "should not run")
+        assert False, "Should have raised CircuitOpenError"
+    except CircuitOpenError:
+        pass
+
+
+def test_success_resets_failure_count() -> None:
+    cb = CircuitBreaker(failure_threshold=3, max_retries=0)
+
+    # Two failures
+    for _ in range(2):
+        try:
+            cb.call(_raise_connection_error)
+        except requests.exceptions.ConnectionError:
+            pass
+
+    # A success should reset the counter
+    cb.call(lambda: "ok")
+    assert cb._consecutive_failures == 0
+
+    # Two more failures should NOT trip the breaker (counter was reset)
+    for _ in range(2):
+        try:
+            cb.call(_raise_connection_error)
+        except requests.exceptions.ConnectionError:
+            pass
+    assert cb.state == CircuitBreaker.CLOSED
+
+
+# ---------------------------------------------------------------------------
+# CircuitBreaker: half-open → recovery
+# ---------------------------------------------------------------------------
+
+
+def test_half_open_probe_success_closes_circuit() -> None:
+    cb = CircuitBreaker(failure_threshold=2, max_retries=0, recovery_timeout=0.05)
+
+    # Trip the breaker
+    for _ in range(2):
+        try:
+            cb.call(_raise_connection_error)
+        except requests.exceptions.ConnectionError:
+            pass
+    assert cb.state == CircuitBreaker.OPEN
+
+    # Wait for recovery timeout (generous margin for CI / Windows timer resolution)
+    time.sleep(0.15)
+    assert cb.state == CircuitBreaker.HALF_OPEN
+
+    # Successful probe should close
+    result = cb.call(lambda: "recovered")
+    assert result == "recovered"
+    assert cb.state == CircuitBreaker.CLOSED
+
+
+def test_half_open_probe_failure_reopens() -> None:
+    cb = CircuitBreaker(failure_threshold=2, max_retries=0, recovery_timeout=0.05)
+
+    # Trip the breaker
+    for _ in range(2):
+        try:
+            cb.call(_raise_connection_error)
+        except requests.exceptions.ConnectionError:
+            pass
+    assert cb.state == CircuitBreaker.OPEN
+
+    # Wait for recovery timeout (generous margin for CI / Windows timer resolution)
+    time.sleep(0.15)
+    assert cb.state == CircuitBreaker.HALF_OPEN
+
+    # Failed probe should reopen
+    try:
+        cb.call(_raise_connection_error)
+    except requests.exceptions.ConnectionError:
+        pass
+    assert cb.state == CircuitBreaker.OPEN
+
+
+# ---------------------------------------------------------------------------
+# CircuitBreaker: manual reset
+# ---------------------------------------------------------------------------
+
+
+def test_manual_reset() -> None:
+    cb = CircuitBreaker(failure_threshold=2, max_retries=0, recovery_timeout=999)
+
+    for _ in range(2):
+        try:
+            cb.call(_raise_connection_error)
+        except requests.exceptions.ConnectionError:
+            pass
+    assert cb.state == CircuitBreaker.OPEN
+
+    cb.reset()
+    assert cb.state == CircuitBreaker.CLOSED
+    result = cb.call(lambda: "after reset")
+    assert result == "after reset"
+
+
+# ---------------------------------------------------------------------------
+# Integration: exa_http_call uses circuit breaker
+# ---------------------------------------------------------------------------
+
+
+def test_exa_http_call_smoke_bypasses_circuit_breaker() -> None:
+    """Smoke mode should not touch the circuit breaker at all."""
+    from exa_demo.client import exa_circuit_breaker, exa_http_call
+    from exa_demo.config import default_config
+
+    # Even if the breaker is open, smoke should work.
+    exa_circuit_breaker.reset()
+    exa_circuit_breaker._state = CircuitBreaker.OPEN
+    exa_circuit_breaker._opened_at = time.monotonic()
+
+    config = default_config()
+    result = exa_http_call(
+        {"query": "test", "numResults": 1},
+        config=config,
+        exa_api_key="",
+        smoke_no_network=True,
+    )
+    assert "results" in result
+
+    # Clean up
+    exa_circuit_breaker.reset()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _raise_connection_error():
+    raise requests.exceptions.ConnectionError("connection refused")


### PR DESCRIPTION
## Summary
- Adds a `CircuitBreaker` class (`resilience.py`) that wraps all live Exa HTTP calls with **exponential backoff + jitter** on transient errors (5xx, timeouts, connection errors) and a **three-state circuit breaker** (closed → open → half-open) that trips after consecutive failures and auto-recovers after a cooldown.
- Non-transient errors (4xx, auth failures) skip retry entirely and fail immediately — no wasted retries on bad requests.
- Smoke mode bypasses the breaker, so tests are unaffected.
- Module-level singleton (`exa_circuit_breaker`) shared across all call sites. Defaults: 5 failure threshold, 30s recovery timeout, 2 retries, 0.5s backoff base.

## Test plan
- [x] 16 new tests covering: `is_transient` classification, basic success, retry-then-succeed, retry-exhausted, non-transient skip, trip-open-after-threshold, success-resets-counter, half-open probe success/failure, manual reset, and smoke-mode bypass integration
- [x] All 225 tests pass (209 existing + 16 new), zero regressions
- [x] Ruff linter clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)