### PR TITLE
feat: add reusable endpoint report exports

### DIFF
--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -2,7 +2,7 @@
 
 _Generated file. Regenerate with `python scripts/generate_heartbeat.py`._
 
-_Generated: 2026-03-27T22:46:51.963062+00:00_
+_Generated: 2026-04-12T01:25:06.552210+00:00_
 
 ## Current status
 - Purpose: Exa-powered insurance intelligence toolkit for CAT-loss, claims, expert, contractor, and market/regulatory research workflows.
@@ -59,21 +59,23 @@ _Generated: 2026-03-27T22:46:51.963062+00:00_
 - Scope beyond this scaffold into auth redesign, persistence implementation, async jobs, deployment, infra, or broader docs refactors.
 
 ## Last session
-- Date: 2026-03-27g
-- Objective: Inspect one collection/list auth boundary involving user-owned data and patch at most one confirmed gap.
+- Date: 2026-04-11
+- Objective: Take a thin follow-on slice on `#14` by adding one reusable markdown export path without widening the workflow surface.
 - Changes made:
-  - Inventoried the collection/list routes in `src/exa_demo/api.py`.
-  - Chose `GET /api/runs` because it exists and is the highest-risk non-`/me` collection route in the current branch state.
-  - Inspected the route in `src/exa_demo/api.py`, the underlying `list_runs(...)` repository call in `src/exa_demo/persistence.py`, the ops gate in `src/exa_demo/api_auth.py`, and the adjacent `/api/runs` auth tests in `tests/test_users.py`.
-  - Confirmed the route already enforces ops-only access before the unscoped repository query can return cross-user run records.
-  - Added a focused no-gap session log for this collection auth audit.
+  - Confirmed the broader `#14` scope was already shipped locally in the roadmap, issue tracker, README, and demo gallery.
+  - Added a shared `report.md` companion artifact for the endpoint-style workflows in `src/exa_demo/endpoint_workflows.py`.
+  - Added `render_endpoint_report_markdown(...)` in `src/exa_demo/reporting.py` to generate stakeholder-friendly markdown for answer, research, structured-search, and find-similar runs.
+  - Updated `README.md` and `docs/demo-gallery.md` so the reusable markdown export path is discoverable.
+  - Added a new session log for the slice and synced the issue-tracker reference to it.
 - Validation:
-  - Ran `python -m pytest tests/test_users.py -q -k "allowlisted_ops_user_sees_all_runs or non_ops_user_cannot_access_global_runs"` and confirmed `2 passed, 22 deselected`.
+  - Ran `python -m pytest -q tests/test_reporting.py tests/test_workflows.py` and confirmed `13 passed`.
+  - Ran `python -m ruff check src/exa_demo/reporting.py src/exa_demo/endpoint_workflows.py tests/test_reporting.py tests/test_workflows.py` and confirmed all checks passed.
 - Open issues:
-  - No confirmed auth gap remains for the inspected `GET /api/runs` boundary.
-  - This slice intentionally did not audit any additional collection routes.
+  - GitHub issue `#14` is still open even though the local roadmap/tracker already treat it as closed work.
+  - This slice intentionally did not touch ranked-search/eval exports or pilot web-product work.
 - Decisions proposed:
-  - Close this slice without product-code changes because the inspected collection boundary is already correctly ops-gated.
+  - Keep future export/report additions additive and artifact-first rather than changing existing JSON workflow contracts.
+  - Treat any GitHub issue closure for `#14` as a repo-governance follow-up once the branch or PR is in place.
 
 ## Next thin slice
-- Inspect one other collection/list route only if it is not `/me/...` scoped, not obviously ops-only, and can expose user-owned data across accounts.
+- Either close the GitHub-side `#14` issue with the corresponding PR, or move directly to `#22` pilot auth/request boundary controls for the next code session.

--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ The `answer` command writes the same run directory and adds an `answer.json` art
 The `research` command writes the same run directory and adds `research.json` plus `research.md` artifacts for the research-report payload.
 The `structured-search` command runs a schema-driven deep search and writes a `structured_output.json` artifact containing the extracted structured payload.
 The `find-similar` command runs a seed-URL discovery workflow and writes a `find_similar.json` artifact containing the similar-result payload.
+The endpoint-style workflows (`answer`, `research`, `structured-search`, and `find-similar`) also emit a reusable `report.md` companion artifact for human review.
 Eval workflows also emit additive export companions such as `results.csv`, `comparison.json`, `grouped_query_outcomes.csv`, and `manifest.json` without changing the existing JSON/JSONL contracts.
 Deep-search-oriented request shaping is now exposed directly in the CLI with additive flags such as `--additional-query`, `--start-published-date`, `--end-published-date`, and `--livecrawl`.
 Search cost estimation can also be overridden from the CLI for search-type experiments with flags such as `--deep-search-cost-1-25` and `--deep-reasoning-search-cost-1-25`.
@@ -320,6 +321,7 @@ Each notebook run now writes a versioned artifact bundle under `experiments/<RUN
 Workflow-specific commands may also add:
 
 - `answer.json`
+- `report.md`
 - `research.json`
 - `research.md`
 - `find_similar.json`
@@ -466,6 +468,5 @@ For a from-scratch architecture critique and refactor roadmap, see `docs/rebuild
 - No contact harvesting
 - Redaction stays enabled in notebook output
 - Human review required before operational use
-
 
 

--- a/docs/demo-gallery.md
+++ b/docs/demo-gallery.md
@@ -55,10 +55,10 @@ python -m exa_demo compare-search-types --mode smoke --suite forensic_and_damage
 | Workflow | Primary artifact |
 | --- | --- |
 | `search` | `results.jsonl`, `summary.json`, `manifest.json` |
-| `answer` | `answer.json`, `summary.json` |
-| `research` | `research.json`, `research.md`, `summary.json` |
-| `structured-search` | `structured_output.json`, `summary.json` |
-| `find-similar` | `find_similar.json`, `summary.json` |
+| `answer` | `answer.json`, `report.md`, `summary.json` |
+| `research` | `research.json`, `research.md`, `report.md`, `summary.json` |
+| `structured-search` | `structured_output.json`, `report.md`, `summary.json` |
+| `find-similar` | `find_similar.json`, `report.md`, `summary.json` |
 | `compare-search-types` | `comparison.md`, `comparison.json`, `grouped_query_outcomes.csv` plus paired run artifacts |
 
 ## Recommended Order

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -31,10 +31,10 @@ Update it whenever issues are created, closed, re-scoped, or moved between miles
 | `#11 Add /research demo for market/regulatory reports` | Task | `Phase 2 - Exa Coverage` | `type:task`, `area:exa-api`, `priority:p1`, `status:ready` | Closed | `#6, #2, #4` | Phase 2 - Exa API Coverage | `https://github.com/itprodirect/exai-insurance-intel/issues/11` | `docs/sessions/2026-03-19-phase3-research-benchmarks-rails.md` |
 | `#12 Epic: Insurance/CAT domain coverage` | Epic | `Phase 3 - Domain/Productization` | `type:epic`, `area:domain`, `priority:p1`, `status:ready` | Open | `#1, #6` | Phase 3 - Domain Coverage and Productization | `https://github.com/itprodirect/exai-insurance-intel/issues/12` | `docs/sessions/2026-03-10-roadmap-baseline.md` |
 | `#13 Expand domain query suites for PA, CAT law, appraisers, IA, and adjacent industries` | Task | `Phase 3 - Domain/Productization` | `type:task`, `area:domain`, `priority:p0`, `status:ready` | Closed | `#12, #4, #5` | Phase 3 - Domain Coverage and Productization | `https://github.com/itprodirect/exai-insurance-intel/issues/13` | `docs/sessions/2026-03-19-phase3-research-benchmarks-rails.md` |
-| `#14 Add export/report outputs and demo-gallery documentation` | Task | `Phase 3 - Domain/Productization` | `type:task`, `area:docs`, `priority:p1`, `status:ready` | Closed | `#12, #7, #8, #13` | Phase 3 - Domain Coverage and Productization | `https://github.com/itprodirect/exai-insurance-intel/issues/14` | `docs/sessions/2026-03-19-phase3-export-outputs-and-smoke-rails.md` |
+| `#14 Add export/report outputs and demo-gallery documentation` | Task | `Phase 3 - Domain/Productization` | `type:task`, `area:docs`, `priority:p1`, `status:ready` | Closed | `#12, #7, #8, #13` | Phase 3 - Domain Coverage and Productization | `https://github.com/itprodirect/exai-insurance-intel/issues/14` | `docs/sessions/2026-04-11-issue-14-report-export.md` |
 | `#15 Epic: Documentation, governance, and repo operations` | Epic | `Phase 3 - Domain/Productization` | `type:epic`, `area:ops`, `priority:p0`, `status:ready` | Open | None | Phase 4 - Documentation, Governance, and Repo Operations | `https://github.com/itprodirect/exai-insurance-intel/issues/15` | `docs/sessions/2026-03-10-roadmap-baseline.md` |
 | `#16 Extend CI/security hardening and document integration follow-ons` | Task | `Phase 3 - Domain/Productization` | `type:task`, `area:ops`, `priority:p1`, `status:ready` | In progress | `#15, #14` | Phase 3 - Domain Coverage and Productization | `https://github.com/itprodirect/exai-insurance-intel/issues/16` | `docs/sessions/2026-03-21-payload-boundary-cleanup.md` |
-| `#17 Maintain roadmap, issue tracker, ADRs, and session notes` | Task | `Phase 3 - Domain/Productization` | `type:task`, `area:docs`, `priority:p0`, `status:ready` | In progress | `#15` | Phase 4 - Documentation, Governance, and Repo Operations | `https://github.com/itprodirect/exai-insurance-intel/issues/17` | `docs/sessions/2026-03-21-payload-boundary-cleanup.md` |
+| `#17 Maintain roadmap, issue tracker, ADRs, and session notes` | Task | `Phase 3 - Domain/Productization` | `type:task`, `area:docs`, `priority:p0`, `status:ready` | In progress | `#15` | Phase 4 - Documentation, Governance, and Repo Operations | `https://github.com/itprodirect/exai-insurance-intel/issues/17` | `docs/sessions/2026-04-11-issue-14-report-export.md` |
 | `#18 Upgrade README with feature matrix, architecture diagram, and roadmap links` | Task | `Phase 3 - Domain/Productization` | `type:task`, `area:docs`, `priority:p1`, `status:ready` | Closed | `#15` | Phase 4 - Documentation, Governance, and Repo Operations | `https://github.com/itprodirect/exai-insurance-intel/issues/18` | `docs/sessions/2026-03-18-phase2-parallel-slices.md` |
 
 ## Phase 5 - Pilot Web Product
@@ -64,7 +64,6 @@ Each slice should be one focused agent session. See [agent-execution-defaults.md
 - Close the roadmap item and issue together, or document why they diverged.
 - Update the `Last-updated session log` field whenever the issue scope, status, or acceptance criteria changes.
 - Record durable process changes in `docs/adr/`.
-
 
 
 

--- a/docs/sessions/2026-04-11-issue-14-report-export.md
+++ b/docs/sessions/2026-04-11-issue-14-report-export.md
@@ -1,0 +1,50 @@
+# Session: Issue 14 reusable endpoint report export
+
+- Date: 2026-04-11
+- Participants: Codex, user
+- Related roadmap items: `#14`, `#17`
+- Related ADRs: none
+
+## Context
+
+Take a thin follow-on slice on `#14 Add export/report outputs and demo-gallery documentation` without reopening broader workflow or frontend scope.
+
+## Repo Facts Observed
+
+- `README.md`, `docs/demo-gallery.md`, and `docs/roadmap.md` already described the broader `#14` export/report and gallery work as shipped.
+- `docs/issue-tracker.md` already marked `#14` closed locally, even though the GitHub issue was still open.
+- The endpoint-style workflows (`answer`, `research`, `structured-search`, `find-similar`) already wrote workflow-specific JSON artifacts, and `research` alone had a markdown companion artifact.
+
+## Decisions Made
+
+- Keep the slice additive by introducing one shared `report.md` companion path for endpoint-style workflows rather than changing existing JSON filenames or payload contracts.
+- Preserve the existing `research.md` artifact and add the new reusable `report.md` beside it instead of renaming or replacing the report-specific markdown path.
+- Limit doc changes to artifact-path references in the README and demo gallery.
+
+## Issues Opened or Updated
+
+- `#14 Add export/report outputs and demo-gallery documentation` — extended with a reusable endpoint `report.md` export follow-on and local tracker/session references.
+- `#17 Maintain roadmap, issue tracker, ADRs, and session notes` — updated indirectly via the issue-tracker/session-note sync required for this slice.
+
+## Docs Touched
+
+- `README.md`
+- `docs/demo-gallery.md`
+- `docs/issue-tracker.md`
+- `docs/sessions/2026-04-11-issue-14-report-export.md`
+
+## Tests and Checks Run
+
+- `python -m pytest -q tests/test_reporting.py tests/test_workflows.py` -> passed (`13 passed`)
+- `python -m ruff check src/exa_demo/reporting.py src/exa_demo/endpoint_workflows.py tests/test_reporting.py tests/test_workflows.py` -> passed
+
+## Outcome
+
+- Added a reusable `report.md` markdown export for `answer`, `research`, `structured-search`, and `find-similar` runs.
+- Preserved the existing JSON artifact contracts and the existing `research.md` artifact.
+- Updated the top-level docs to point at the new shared markdown export path.
+
+## Next-Session Handoff
+
+- Close or reconcile the still-open GitHub `#14` issue once the corresponding PR is opened or merged.
+- The next higher-value coding slice remains `#22` pilot auth/request boundary controls if the session should stay aligned with the current repo focus.

--- a/heartbeat.json
+++ b/heartbeat.json
@@ -1,6 +1,6 @@
 {
   "repo": "exai-insurance-intel",
-  "generated_at": "2026-03-27T22:46:51.963062+00:00",
+  "generated_at": "2026-04-12T01:25:06.552210+00:00",
   "purpose": "Exa-powered insurance intelligence toolkit for CAT-loss, claims, expert, contractor, and market/regulatory research workflows.",
   "strategic_role": "Workflow engine plus controlled pilot web-product base for internal insurance-intelligence validation.",
   "current_milestone": "Phase 5 Level 1 is partially complete: the thin FastAPI wrapper and frontend shell are shipped, while pilot auth/request controls and persistence baseline remain the next bounded slices.",
@@ -51,30 +51,32 @@
   ],
   "update_policy": "`MEMORY.md` stays curated and human-reviewed. `memory/YYYY-MM-DD.md` stays append-only. `HEARTBEAT.md` and `heartbeat.json` are reproducible generated outputs and are never the durable source of truth.",
   "last_session": {
-    "date": "2026-03-27g",
-    "objective": "Inspect one collection/list auth boundary involving user-owned data and patch at most one confirmed gap.",
+    "date": "2026-04-11",
+    "objective": "Take a thin follow-on slice on `#14` by adding one reusable markdown export path without widening the workflow surface.",
     "changes_made": [
-      "Inventoried the collection/list routes in `src/exa_demo/api.py`.",
-      "Chose `GET /api/runs` because it exists and is the highest-risk non-`/me` collection route in the current branch state.",
-      "Inspected the route in `src/exa_demo/api.py`, the underlying `list_runs(...)` repository call in `src/exa_demo/persistence.py`, the ops gate in `src/exa_demo/api_auth.py`, and the adjacent `/api/runs` auth tests in `tests/test_users.py`.",
-      "Confirmed the route already enforces ops-only access before the unscoped repository query can return cross-user run records.",
-      "Added a focused no-gap session log for this collection auth audit."
+      "Confirmed the broader `#14` scope was already shipped locally in the roadmap, issue tracker, README, and demo gallery.",
+      "Added a shared `report.md` companion artifact for the endpoint-style workflows in `src/exa_demo/endpoint_workflows.py`.",
+      "Added `render_endpoint_report_markdown(...)` in `src/exa_demo/reporting.py` to generate stakeholder-friendly markdown for answer, research, structured-search, and find-similar runs.",
+      "Updated `README.md` and `docs/demo-gallery.md` so the reusable markdown export path is discoverable.",
+      "Added a new session log for the slice and synced the issue-tracker reference to it."
     ],
     "validation_run": [
-      "Ran `python -m pytest tests/test_users.py -q -k \"allowlisted_ops_user_sees_all_runs or non_ops_user_cannot_access_global_runs\"` and confirmed `2 passed, 22 deselected`."
+      "Ran `python -m pytest -q tests/test_reporting.py tests/test_workflows.py` and confirmed `13 passed`.",
+      "Ran `python -m ruff check src/exa_demo/reporting.py src/exa_demo/endpoint_workflows.py tests/test_reporting.py tests/test_workflows.py` and confirmed all checks passed."
     ],
     "open_issues": [
-      "No confirmed auth gap remains for the inspected `GET /api/runs` boundary.",
-      "This slice intentionally did not audit any additional collection routes."
+      "GitHub issue `#14` is still open even though the local roadmap/tracker already treat it as closed work.",
+      "This slice intentionally did not touch ranked-search/eval exports or pilot web-product work."
     ],
     "decisions_proposed": [
-      "Close this slice without product-code changes because the inspected collection boundary is already correctly ops-gated."
+      "Keep future export/report additions additive and artifact-first rather than changing existing JSON workflow contracts.",
+      "Treat any GitHub issue closure for `#14` as a repo-governance follow-up once the branch or PR is in place."
     ],
     "next_thin_slice": [
-      "Inspect one other collection/list route only if it is not `/me/...` scoped, not obviously ops-only, and can expose user-owned data across accounts."
+      "Either close the GitHub-side `#14` issue with the corresponding PR, or move directly to `#22` pilot auth/request boundary controls for the next code session."
     ]
   },
   "next_thin_slice": [
-    "Inspect one other collection/list route only if it is not `/me/...` scoped, not obviously ops-only, and can expose user-owned data across accounts."
+    "Either close the GitHub-side `#14` issue with the corresponding PR, or move directly to `#22` pilot auth/request boundary controls for the next code session."
   ]
 }

--- a/memory/2026-04-11.md
+++ b/memory/2026-04-11.md
@@ -1,0 +1,26 @@
+# Session Memory
+
+## Objective
+Take a thin follow-on slice on `#14` by adding one reusable markdown export path without widening the workflow surface.
+
+## Changes made
+- Confirmed the broader `#14` scope was already shipped locally in the roadmap, issue tracker, README, and demo gallery.
+- Added a shared `report.md` companion artifact for the endpoint-style workflows in `src/exa_demo/endpoint_workflows.py`.
+- Added `render_endpoint_report_markdown(...)` in `src/exa_demo/reporting.py` to generate stakeholder-friendly markdown for answer, research, structured-search, and find-similar runs.
+- Updated `README.md` and `docs/demo-gallery.md` so the reusable markdown export path is discoverable.
+- Added a new session log for the slice and synced the issue-tracker reference to it.
+
+## Validation run
+- Ran `python -m pytest -q tests/test_reporting.py tests/test_workflows.py` and confirmed `13 passed`.
+- Ran `python -m ruff check src/exa_demo/reporting.py src/exa_demo/endpoint_workflows.py tests/test_reporting.py tests/test_workflows.py` and confirmed all checks passed.
+
+## Open issues
+- GitHub issue `#14` is still open even though the local roadmap/tracker already treat it as closed work.
+- This slice intentionally did not touch ranked-search/eval exports or pilot web-product work.
+
+## Decisions proposed
+- Keep future export/report additions additive and artifact-first rather than changing existing JSON workflow contracts.
+- Treat any GitHub issue closure for `#14` as a repo-governance follow-up once the branch or PR is in place.
+
+## Next thin slice
+- Either close the GitHub-side `#14` issue with the corresponding PR, or move directly to `#22` pilot auth/request boundary controls for the next code session.

--- a/src/exa_demo/endpoint_workflows.py
+++ b/src/exa_demo/endpoint_workflows.py
@@ -10,7 +10,7 @@ from .artifacts import ExperimentArtifactWriter
 from .cache import SqliteCacheStore
 from .client import exa_answer, exa_find_similar, exa_research, exa_structured_search
 from .models import ResearchRecord
-from .reporting import render_research_markdown
+from .reporting import render_endpoint_report_markdown, render_research_markdown
 from .workflows import (
     build_answer_artifact,
     build_find_similar_artifact,
@@ -57,6 +57,16 @@ def run_answer_workflow(
         runtime_metadata=runtime_metadata,
     )
     writer.write_json_artifact("answer.json", answer_payload)
+    writer.write_text_artifact(
+        "report.md",
+        render_endpoint_report_markdown(
+            workflow="answer",
+            run_id=runtime.run_id,
+            payload=answer_payload,
+            summary=summary,
+        ),
+        kind="markdown",
+    )
     _write_endpoint_summary(
         writer,
         summary,
@@ -143,6 +153,16 @@ def run_research_workflow(
         runtime_metadata=runtime_metadata,
     )
     writer.write_json_artifact("research.json", research_payload)
+    writer.write_text_artifact(
+        "report.md",
+        render_endpoint_report_markdown(
+            workflow="research",
+            run_id=runtime.run_id,
+            payload=research_payload,
+            summary=summary,
+        ),
+        kind="markdown",
+    )
     writer.write_text_artifact(
         "research.md",
         render_research_markdown(
@@ -242,6 +262,16 @@ def run_find_similar_workflow(
         runtime_metadata=runtime_metadata,
     )
     writer.write_json_artifact("find_similar.json", find_similar_payload)
+    writer.write_text_artifact(
+        "report.md",
+        render_endpoint_report_markdown(
+            workflow="find-similar",
+            run_id=runtime.run_id,
+            payload=find_similar_payload,
+            summary=summary,
+        ),
+        kind="markdown",
+    )
     _write_endpoint_summary(
         writer,
         summary,
@@ -337,6 +367,16 @@ def run_structured_search_workflow(
         runtime_metadata=runtime_metadata,
     )
     writer.write_json_artifact("structured_output.json", structured_payload)
+    writer.write_text_artifact(
+        "report.md",
+        render_endpoint_report_markdown(
+            workflow="structured-search",
+            run_id=runtime.run_id,
+            payload=structured_payload,
+            summary=summary,
+        ),
+        kind="markdown",
+    )
     _write_endpoint_summary(
         writer,
         summary,

--- a/src/exa_demo/reporting.py
+++ b/src/exa_demo/reporting.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import Any, Dict, List, Mapping
 
 import pandas as pd
@@ -294,6 +295,91 @@ def render_research_markdown(
     return "\n".join(lines).strip() + "\n"
 
 
+def render_endpoint_report_markdown(
+    *,
+    workflow: str,
+    run_id: str,
+    payload: Mapping[str, Any],
+    summary: Mapping[str, Any] | None = None,
+) -> str:
+    lines: List[str] = []
+    lines.append(f"# {_workflow_report_title(workflow)}")
+    lines.append("")
+    lines.append(f"- Workflow: `{workflow}`")
+    lines.append(f"- Run ID: `{run_id}`")
+
+    query = str(payload.get("query") or "").strip()
+    if query:
+        lines.append(f"- Query: `{query}`")
+
+    seed_url = str(payload.get("seed_url") or "").strip()
+    if seed_url:
+        lines.append(f"- Seed URL: {seed_url}")
+
+    if "cache_hit" in payload:
+        lines.append(f"- Cache hit: `{str(bool(payload.get('cache_hit'))).lower()}`")
+
+    request_id = str(payload.get("request_id") or "").strip()
+    if request_id:
+        lines.append(f"- Request ID: `{request_id}`")
+
+    if summary:
+        lines.append(f"- Requests this run: `{int(summary.get('request_count', 0) or 0)}`")
+        lines.append(f"- Spend this run (USD): `{float(summary.get('spent_usd', 0.0) or 0.0):.4f}`")
+
+    lines.append("")
+
+    if workflow == "answer":
+        lines.append("## Answer")
+        lines.append("")
+        lines.append(str(payload.get("answer_text") or "No answer text returned.").strip())
+        _append_citations_section(lines, payload.get("citations"))
+    elif workflow == "research":
+        lines.append("## Report")
+        lines.append("")
+        lines.append(str(payload.get("report_text") or "No report text returned.").strip())
+        _append_citations_section(lines, payload.get("citations"))
+    elif workflow == "structured-search":
+        lines.append("## Structured Output")
+        lines.append("")
+        schema_file = str(payload.get("schema_file") or "").strip()
+        if schema_file:
+            lines.append(f"- Schema file: `{schema_file}`")
+        keys = payload.get("structured_output_keys")
+        if isinstance(keys, list) and keys:
+            lines.append(f"- Output keys: `{', '.join(str(key) for key in keys)}`")
+        structured_output = payload.get("structured_output")
+        lines.append("")
+        lines.append("```json")
+        lines.append(json.dumps(structured_output, indent=2, sort_keys=True, ensure_ascii=False))
+        lines.append("```")
+    elif workflow == "find-similar":
+        top_result = payload.get("top_result")
+        lines.append("## Top Result")
+        lines.append("")
+        if isinstance(top_result, Mapping):
+            _append_find_similar_result(lines, top_result)
+        else:
+            lines.append("No similar results returned.")
+        results = payload.get("results")
+        if isinstance(results, list) and results:
+            lines.append("")
+            lines.append("## Result Preview")
+            lines.append("")
+            for item in results[:5]:
+                if not isinstance(item, Mapping):
+                    continue
+                _append_find_similar_result(lines, item)
+    else:
+        lines.append("## Payload")
+        lines.append("")
+        lines.append("```json")
+        lines.append(json.dumps(dict(payload), indent=2, sort_keys=True, ensure_ascii=False))
+        lines.append("```")
+
+    return "\n".join(lines).strip() + "\n"
+
+
 def _mean_score(df: pd.DataFrame, column: str, fallback_column: str | None = None) -> float:
     if column in df.columns:
         observed = pd.to_numeric(df[column], errors="coerce").dropna()
@@ -306,3 +392,50 @@ def _mean_score(df: pd.DataFrame, column: str, fallback_column: str | None = Non
             return float(fallback.mean())
 
     return 0.0
+
+
+def _workflow_report_title(workflow: str) -> str:
+    titles = {
+        "answer": "Answer Workflow Report",
+        "research": "Research Workflow Report",
+        "structured-search": "Structured Search Workflow Report",
+        "find-similar": "Find Similar Workflow Report",
+    }
+    return titles.get(workflow, "Workflow Report")
+
+
+def _append_citations_section(lines: List[str], citations: Any) -> None:
+    if not isinstance(citations, list) or not citations:
+        return
+
+    lines.append("")
+    lines.append("## Citations")
+    lines.append("")
+    for citation in citations:
+        if not isinstance(citation, Mapping):
+            continue
+        title = str(citation.get("title") or "Untitled source").strip()
+        url = str(citation.get("url") or "").strip()
+        snippet = str(citation.get("snippet") or "").strip()
+        if url:
+            lines.append(f"- [{title}]({url})")
+        else:
+            lines.append(f"- {title}")
+        if snippet:
+            lines.append(f"  Snippet: {snippet}")
+
+
+def _append_find_similar_result(lines: List[str], result: Mapping[str, Any]) -> None:
+    title = str(result.get("title") or "Untitled result").strip()
+    url = str(result.get("url") or "").strip()
+    snippet = str(result.get("snippet") or "").strip()
+    score = result.get("score")
+
+    if url:
+        lines.append(f"- [{title}]({url})")
+    else:
+        lines.append(f"- {title}")
+    if snippet:
+        lines.append(f"  Snippet: {snippet}")
+    if score is not None:
+        lines.append(f"  Score: {score}")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -462,6 +462,7 @@ def test_answer_command_smoke_emits_json_and_artifact(tmp_path, capsys) -> None:
     assert output['citation_count'] == 2
     assert 'Mock answer' in output['answer']
     assert (artifact_dir / 'answer-run' / 'answer.json').exists()
+    assert (artifact_dir / 'answer-run' / 'report.md').exists()
     assert (artifact_dir / 'answer-run' / 'summary.json').exists()
     answer_payload = json.loads((artifact_dir / 'answer-run' / 'answer.json').read_text(encoding='utf-8'))
     assert answer_payload['citation_count'] == 2
@@ -497,6 +498,7 @@ def test_research_command_smoke_emits_json_and_artifact(tmp_path, capsys) -> Non
     assert 'Mock research report' in output['report']
     assert (artifact_dir / 'research-run' / 'research.json').exists()
     assert (artifact_dir / 'research-run' / 'research.md').exists()
+    assert (artifact_dir / 'research-run' / 'report.md').exists()
     assert (artifact_dir / 'research-run' / 'summary.json').exists()
     research_payload = json.loads((artifact_dir / 'research-run' / 'research.json').read_text(encoding='utf-8'))
     assert research_payload['citation_count'] == 3
@@ -575,6 +577,7 @@ def test_structured_search_command_smoke_emits_json_and_artifact(tmp_path, capsy
     assert output['structured_output']['schema_title'] == 'Structured Professionals'
     assert output['structured_output']['field_names'] == ['name', 'role']
     assert (artifact_dir / 'structured-run' / 'structured_output.json').exists()
+    assert (artifact_dir / 'structured-run' / 'report.md').exists()
     assert (artifact_dir / 'structured-run' / 'summary.json').exists()
     structured_payload = json.loads((artifact_dir / 'structured-run' / 'structured_output.json').read_text(encoding='utf-8'))
     assert structured_payload['structured_output']['record_count'] == 1
@@ -638,6 +641,7 @@ def test_find_similar_command_smoke_emits_json_and_artifact(tmp_path, capsys) ->
     assert output['result_count'] == 3
     assert output['top_result']['title'] == 'Florida Insurance Litigation Firm'
     assert (artifact_dir / 'find-similar-run' / 'find_similar.json').exists()
+    assert (artifact_dir / 'find-similar-run' / 'report.md').exists()
     assert (artifact_dir / 'find-similar-run' / 'summary.json').exists()
     artifact_payload = json.loads((artifact_dir / 'find-similar-run' / 'find_similar.json').read_text(encoding='utf-8'))
     assert artifact_payload['seed_url'] == 'https://www.merlinlawgroup.com/'

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -6,6 +6,7 @@ import pandas as pd
 
 from exa_demo.reporting import (
     build_before_after_report,
+    render_endpoint_report_markdown,
     render_research_markdown,
     render_comparison_markdown,
     summarize_failure_taxonomy,
@@ -280,4 +281,51 @@ def test_render_research_markdown_includes_report_and_citations() -> None:
     assert 'Summarize the Florida CAT market outlook.' in markdown
     assert 'Mock research report body.' in markdown
     assert '[Florida market bulletin](https://example.com/bulletin)' in markdown
+
+
+def test_render_endpoint_report_markdown_for_answer_includes_summary_and_citations() -> None:
+    markdown = render_endpoint_report_markdown(
+        workflow='answer',
+        run_id='answer-run',
+        payload={
+            'query': 'What is the Florida appraisal clause dispute process?',
+            'answer_text': 'Mock answer text.',
+            'citations': [
+                {
+                    'title': 'Florida appraisal clause overview',
+                    'url': 'https://example.com/florida-appraisal-clause',
+                    'snippet': 'Mock citation.',
+                }
+            ],
+            'cache_hit': False,
+            'request_id': 'smoke-answer-1',
+        },
+        summary={'request_count': 1, 'spent_usd': 0.0},
+    )
+
+    assert '# Answer Workflow Report' in markdown
+    assert 'What is the Florida appraisal clause dispute process?' in markdown
+    assert 'Mock answer text.' in markdown
+    assert '[Florida appraisal clause overview](https://example.com/florida-appraisal-clause)' in markdown
+    assert '- Requests this run: `1`' in markdown
+
+
+def test_render_endpoint_report_markdown_for_structured_search_includes_json_block() -> None:
+    markdown = render_endpoint_report_markdown(
+        workflow='structured-search',
+        run_id='structured-run',
+        payload={
+            'query': 'independent adjuster florida catastrophe claims',
+            'schema_file': 'schema.json',
+            'structured_output_keys': ['field_names', 'records'],
+            'structured_output': {'field_names': ['name'], 'records': [{'name': 'Jane Doe'}]},
+            'cache_hit': True,
+        },
+        summary={'request_count': 1, 'spent_usd': 0.02},
+    )
+
+    assert '# Structured Search Workflow Report' in markdown
+    assert '- Schema file: `schema.json`' in markdown
+    assert '"name": "Jane Doe"' in markdown
+    assert '```json' in markdown
 

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -159,10 +159,13 @@ def test_run_answer_workflow_smoke_writes_summary_context(tmp_path) -> None:
 
     run_dir = tmp_path / 'artifacts' / 'workflow-answer'
     summary_payload = json.loads((run_dir / 'summary.json').read_text(encoding='utf-8'))
+    report_markdown = (run_dir / 'report.md').read_text(encoding='utf-8')
 
     assert payload['workflow'] == 'answer'
     assert payload['citation_count'] == 2
     assert 'Mock answer' in payload['answer']
+    assert '# Answer Workflow Report' in report_markdown
+    assert 'Florida appraisal clause overview' in report_markdown
     assert summary_payload['extra']['workflow'] == 'answer'
     assert summary_payload['extra']['answer']['citation_count'] == 2
     assert summary_payload['qualitative_notes'] == [
@@ -188,11 +191,14 @@ def test_run_research_workflow_smoke_writes_markdown_and_summary_context(tmp_pat
     run_dir = tmp_path / 'artifacts' / 'workflow-research'
     summary_payload = json.loads((run_dir / 'summary.json').read_text(encoding='utf-8'))
     markdown = (run_dir / 'research.md').read_text(encoding='utf-8')
+    report_markdown = (run_dir / 'report.md').read_text(encoding='utf-8')
 
     assert payload['workflow'] == 'research'
     assert payload['citation_count'] == 3
     assert 'Mock research report' in (payload['report'] or '')
     assert '# Research Report' in markdown
+    assert '# Research Workflow Report' in report_markdown
+    assert 'Mock Research Source 1' in report_markdown
     assert summary_payload['extra']['workflow'] == 'research'
     assert summary_payload['extra']['research']['citation_count'] == 3
     assert summary_payload['qualitative_notes'] == [
@@ -263,11 +269,16 @@ def test_run_find_similar_workflow_smoke_caps_requested_results(tmp_path, monkey
     summary_payload = json.loads(
         (tmp_path / 'artifacts' / 'workflow-find-similar' / 'summary.json').read_text(encoding='utf-8')
     )
+    report_markdown = (
+        tmp_path / 'artifacts' / 'workflow-find-similar' / 'report.md'
+    ).read_text(encoding='utf-8')
 
     assert captured['url'] == 'https://www.merlinlawgroup.com/'
     assert captured['num_results'] == 3
     assert payload['result_count'] == 1
     assert payload['top_result']['title'] == 'Florida Insurance Litigation Firm'
+    assert '# Find Similar Workflow Report' in report_markdown
+    assert 'Florida Insurance Litigation Firm' in report_markdown
     assert summary_payload['extra']['workflow'] == 'find-similar'
     assert summary_payload['extra']['find_similar']['result_count'] == 1
 
@@ -301,11 +312,15 @@ def test_run_structured_search_workflow_smoke_writes_schema_context(tmp_path) ->
         runtime_metadata=_runtime_metadata(runtime),
     )
 
-    summary_payload = json.loads((tmp_path / 'artifacts' / 'workflow-structured' / 'summary.json').read_text(encoding='utf-8'))
+    run_dir = tmp_path / 'artifacts' / 'workflow-structured'
+    summary_payload = json.loads((run_dir / 'summary.json').read_text(encoding='utf-8'))
+    report_markdown = (run_dir / 'report.md').read_text(encoding='utf-8')
 
     assert payload['workflow'] == 'structured-search'
     assert payload['schema_file'] == str(schema_file)
     assert payload['structured_output']['schema_title'] == 'Structured Professionals'
+    assert '# Structured Search Workflow Report' in report_markdown
+    assert 'Structured Professionals' in report_markdown
     assert summary_payload['extra']['workflow'] == 'structured-search'
     assert summary_payload['extra']['structured_search']['schema_file'] == str(schema_file)
     assert summary_payload['extra']['structured_search']['structured_keys'] == [


### PR DESCRIPTION
## Summary
- add a reusable `report.md` companion artifact for `answer`, `research`, `structured-search`, and `find-similar` runs
- keep the existing JSON and research-markdown contracts intact while updating focused docs and tests
- sync the issue tracker, session log, memory entry, and heartbeat sidecars for the bounded `#14` follow-on slice

## Validation
- `python -m pytest -q tests/test_reporting.py tests/test_workflows.py`
- `python -m pytest -q tests/test_cli.py -k "answer_command_smoke_emits_json_and_artifact or research_command_smoke_emits_json_and_artifact or structured_search_command_smoke_emits_json_and_artifact or find_similar_command_smoke_emits_json_and_artifact"`
- `python -m ruff check src/exa_demo/reporting.py src/exa_demo/endpoint_workflows.py tests/test_reporting.py tests/test_workflows.py`
- `python -m ruff check tests/test_cli.py`

Closes #14
