### PR TITLE
fix: isolate multi-user rate limit buckets

### DIFF
--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -2,7 +2,7 @@
 
 _Generated file. Regenerate with `python scripts/generate_heartbeat.py`._
 
-_Generated: 2026-04-12T01:25:06.552210+00:00_
+_Generated: 2026-04-12T01:39:04.067897+00:00_
 
 ## Current status
 - Purpose: Exa-powered insurance intelligence toolkit for CAT-loss, claims, expert, contractor, and market/regulatory research workflows.
@@ -59,23 +59,23 @@ _Generated: 2026-04-12T01:25:06.552210+00:00_
 - Scope beyond this scaffold into auth redesign, persistence implementation, async jobs, deployment, infra, or broader docs refactors.
 
 ## Last session
-- Date: 2026-04-11
-- Objective: Take a thin follow-on slice on `#14` by adding one reusable markdown export path without widening the workflow surface.
+- Date: 2026-04-11a
+- Objective: Harden one real multi-user request-boundary gap inside `#22` without widening the auth design.
 - Changes made:
-  - Confirmed the broader `#14` scope was already shipped locally in the roadmap, issue tracker, README, and demo gallery.
-  - Added a shared `report.md` companion artifact for the endpoint-style workflows in `src/exa_demo/endpoint_workflows.py`.
-  - Added `render_endpoint_report_markdown(...)` in `src/exa_demo/reporting.py` to generate stakeholder-friendly markdown for answer, research, structured-search, and find-similar runs.
-  - Updated `README.md` and `docs/demo-gallery.md` so the reusable markdown export path is discoverable.
-  - Added a new session log for the slice and synced the issue-tracker reference to it.
+  - Inspected the shipped pilot API auth layer in `src/exa_demo/api_auth.py` and the FastAPI boundary usage in `src/exa_demo/api.py`.
+  - Confirmed the existing limiter keyed all requests by client IP, including authenticated multi-user traffic.
+  - Added `_rate_limit_key(request)` so multi-user mode isolates rate-limit buckets per resolved authenticated user while single-key and no-auth modes keep the existing per-IP behavior.
+  - Added focused coverage in `tests/test_api_auth.py` proving Alice and Bob do not consume each other's quota in multi-user mode.
+  - Synced the local security doc and tracker/session pointers for the slice.
 - Validation:
-  - Ran `python -m pytest -q tests/test_reporting.py tests/test_workflows.py` and confirmed `13 passed`.
-  - Ran `python -m ruff check src/exa_demo/reporting.py src/exa_demo/endpoint_workflows.py tests/test_reporting.py tests/test_workflows.py` and confirmed all checks passed.
+  - Ran `python -m pytest -q tests/test_api_auth.py` and confirmed `22 passed`.
+  - Ran `python -m ruff check src/exa_demo/api_auth.py tests/test_api_auth.py` and confirmed all checks passed.
 - Open issues:
-  - GitHub issue `#14` is still open even though the local roadmap/tracker already treat it as closed work.
-  - This slice intentionally did not touch ranked-search/eval exports or pilot web-product work.
+  - GitHub issue tracking is still behind the local tracker for the current Phase 5 slices; `#22` exists only in repo docs today.
+  - This slice intentionally did not change single-key/no-auth rate limiting, saved-query validation, or persistence behavior.
 - Decisions proposed:
-  - Keep future export/report additions additive and artifact-first rather than changing existing JSON workflow contracts.
-  - Treat any GitHub issue closure for `#14` as a repo-governance follow-up once the branch or PR is in place.
+  - Continue treating `#22` as a sequence of thin, evidence-backed request-boundary fixes rather than a single broad auth rewrite.
+  - Prefer fixes that are directly tied to one inspected route or helper plus one focused regression test.
 
 ## Next thin slice
-- Either close the GitHub-side `#14` issue with the corresponding PR, or move directly to `#22` pilot auth/request boundary controls for the next code session.
+- Inspect one more request-boundary gap under `#22`, with saved-query input bounds or run-list pagination bounds as the best next candidates.

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -34,7 +34,7 @@ Update it whenever issues are created, closed, re-scoped, or moved between miles
 | `#14 Add export/report outputs and demo-gallery documentation` | Task | `Phase 3 - Domain/Productization` | `type:task`, `area:docs`, `priority:p1`, `status:ready` | Closed | `#12, #7, #8, #13` | Phase 3 - Domain Coverage and Productization | `https://github.com/itprodirect/exai-insurance-intel/issues/14` | `docs/sessions/2026-04-11-issue-14-report-export.md` |
 | `#15 Epic: Documentation, governance, and repo operations` | Epic | `Phase 3 - Domain/Productization` | `type:epic`, `area:ops`, `priority:p0`, `status:ready` | Open | None | Phase 4 - Documentation, Governance, and Repo Operations | `https://github.com/itprodirect/exai-insurance-intel/issues/15` | `docs/sessions/2026-03-10-roadmap-baseline.md` |
 | `#16 Extend CI/security hardening and document integration follow-ons` | Task | `Phase 3 - Domain/Productization` | `type:task`, `area:ops`, `priority:p1`, `status:ready` | In progress | `#15, #14` | Phase 3 - Domain Coverage and Productization | `https://github.com/itprodirect/exai-insurance-intel/issues/16` | `docs/sessions/2026-03-21-payload-boundary-cleanup.md` |
-| `#17 Maintain roadmap, issue tracker, ADRs, and session notes` | Task | `Phase 3 - Domain/Productization` | `type:task`, `area:docs`, `priority:p0`, `status:ready` | In progress | `#15` | Phase 4 - Documentation, Governance, and Repo Operations | `https://github.com/itprodirect/exai-insurance-intel/issues/17` | `docs/sessions/2026-04-11-issue-14-report-export.md` |
+| `#17 Maintain roadmap, issue tracker, ADRs, and session notes` | Task | `Phase 3 - Domain/Productization` | `type:task`, `area:docs`, `priority:p0`, `status:ready` | In progress | `#15` | Phase 4 - Documentation, Governance, and Repo Operations | `https://github.com/itprodirect/exai-insurance-intel/issues/17` | `docs/sessions/2026-04-11-issue-22-rate-limit-scope.md` |
 | `#18 Upgrade README with feature matrix, architecture diagram, and roadmap links` | Task | `Phase 3 - Domain/Productization` | `type:task`, `area:docs`, `priority:p1`, `status:ready` | Closed | `#15` | Phase 4 - Documentation, Governance, and Repo Operations | `https://github.com/itprodirect/exai-insurance-intel/issues/18` | `docs/sessions/2026-03-18-phase2-parallel-slices.md` |
 
 ## Phase 5 - Pilot Web Product
@@ -44,7 +44,7 @@ Update it whenever issues are created, closed, re-scoped, or moved between miles
 | `#19 Epic: Pilot web product layer` | Epic | `Phase 5 - Pilot` | `type:epic`, `area:pilot`, `priority:p0`, `status:ready` | Open | Phases 1-4 | Phase 5 - Pilot Web Product | TBD | `docs/sessions/2026-03-22-pilot-alignment.md` |
 | `#20 Thin FastAPI wrapper over existing workflows` | Task | `Phase 5 - Pilot` | `type:task`, `area:api`, `priority:p0`, `status:done` | Done | `#19` | Phase 5 Level 1 | TBD | `docs/sessions/2026-03-22-api-wrapper.md` |
 | `#21 Frontend app shell (Next.js + Tailwind + shadcn/ui)` | Task | `Phase 5 - Pilot` | `type:task`, `area:frontend`, `priority:p0`, `status:done` | Done | `#19, #20` | Phase 5 Level 1 | TBD | `docs/sessions/2026-03-22-frontend-shell.md` |
-| `#22 Pilot auth + request/budget boundary controls` | Task | `Phase 5 - Pilot` | `type:task`, `area:auth`, `priority:p0`, `status:next` | Next | `#19, #20` | Phase 5 Level 1 | TBD | `docs/sessions/2026-03-22-pilot-alignment.md` |
+| `#22 Pilot auth + request/budget boundary controls` | Task | `Phase 5 - Pilot` | `type:task`, `area:auth`, `priority:p0`, `status:next` | Next | `#19, #20` | Phase 5 Level 1 | TBD | `docs/sessions/2026-04-11-issue-22-rate-limit-scope.md` |
 | `#23 Persistence/state baseline (S3 artifacts + Postgres usage)` | Task | `Phase 5 - Pilot` | `type:task`, `area:infra`, `priority:p1`, `status:next` | Next | `#19, #20` | Phase 5 Level 1 | TBD | `docs/sessions/2026-03-22-pilot-alignment.md` |
 
 ### Next Coding Slices (Sequenced)
@@ -64,6 +64,5 @@ Each slice should be one focused agent session. See [agent-execution-defaults.md
 - Close the roadmap item and issue together, or document why they diverged.
 - Update the `Last-updated session log` field whenever the issue scope, status, or acceptance criteria changes.
 - Record durable process changes in `docs/adr/`.
-
 
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -47,7 +47,7 @@ Install with: `pre-commit install`
 
 ### API Authentication (`api_auth.py`)
 - Bearer token validation (multi-user or single shared key)
-- Per-IP sliding-window rate limiting (default 60 req/min, returns 429)
+- Sliding-window rate limiting (default 60 req/min, returns 429). Multi-user mode isolates buckets per authenticated user; single-key and no-auth modes fall back to per-IP limiting.
 - Ops user allowlist for admin endpoints
 - Live mode gated behind `PILOT_ALLOW_LIVE_MODE=1`
 

--- a/docs/sessions/2026-04-11-issue-22-rate-limit-scope.md
+++ b/docs/sessions/2026-04-11-issue-22-rate-limit-scope.md
@@ -1,0 +1,49 @@
+# Session: Issue 22 rate-limit scope isolation
+
+- Date: 2026-04-11
+- Participants: Codex, user
+- Related roadmap items: `#22`, `#17`
+- Related ADRs: none
+
+## Context
+
+Take the thinnest evidence-backed auth/request-boundary slice inside `#22` by inspecting the shipped pilot API controls and hardening one real multi-user gap without redesigning auth.
+
+## Repo Facts Observed
+
+- `src/exa_demo/api_auth.py` already shipped bearer auth, ops allowlisting, mode/query guards, request logging, and a rate limiter.
+- The current limiter keyed all requests by client IP, even in multi-user mode after bearer auth had already resolved a concrete `user_id`.
+- `tests/test_api_auth.py` covered limit enforcement in single-key mode but did not verify isolation between different authenticated users.
+
+## Decisions Made
+
+- Keep the rate limiter behavior unchanged for single-key and no-auth modes by preserving the existing per-IP buckets there.
+- In multi-user mode only, key the limiter by resolved authenticated user ID so one user's traffic cannot consume another user's allowance when they share a client IP.
+- Stop after this one boundary fix rather than broadening into auth redesign, persistence, or UI work.
+
+## Issues Opened or Updated
+
+- `#22 Pilot auth + request/budget boundary controls` — advanced with a narrow multi-user rate-limit isolation fix and updated local tracker pointer.
+- `#17 Maintain roadmap, issue tracker, ADRs, and session notes` — updated indirectly through required session/memory/heartbeat sync.
+
+## Docs Touched
+
+- `docs/security.md`
+- `docs/issue-tracker.md`
+- `docs/sessions/2026-04-11-issue-22-rate-limit-scope.md`
+
+## Tests and Checks Run
+
+- `python -m pytest -q tests/test_api_auth.py` -> passed (`22 passed`)
+- `python -m ruff check src/exa_demo/api_auth.py tests/test_api_auth.py` -> passed
+
+## Outcome
+
+- Hardened the pilot API rate limiter so multi-user deployments isolate request quotas per authenticated user instead of sharing a single IP bucket.
+- Added focused regression coverage for the new behavior.
+- Kept the change additive and limited to the auth/request-boundary layer.
+
+## Next-Session Handoff
+
+- If `#22` continues, the next similarly thin slice is to inspect one more request-boundary gap such as saved-query input validation or run-list pagination bounds.
+- The larger follow-on after auth/request hardening remains `#23` persistence/state baseline, but only after the boundary slice is considered sufficient.

--- a/heartbeat.json
+++ b/heartbeat.json
@@ -1,6 +1,6 @@
 {
   "repo": "exai-insurance-intel",
-  "generated_at": "2026-04-12T01:25:06.552210+00:00",
+  "generated_at": "2026-04-12T01:39:04.067897+00:00",
   "purpose": "Exa-powered insurance intelligence toolkit for CAT-loss, claims, expert, contractor, and market/regulatory research workflows.",
   "strategic_role": "Workflow engine plus controlled pilot web-product base for internal insurance-intelligence validation.",
   "current_milestone": "Phase 5 Level 1 is partially complete: the thin FastAPI wrapper and frontend shell are shipped, while pilot auth/request controls and persistence baseline remain the next bounded slices.",
@@ -51,32 +51,32 @@
   ],
   "update_policy": "`MEMORY.md` stays curated and human-reviewed. `memory/YYYY-MM-DD.md` stays append-only. `HEARTBEAT.md` and `heartbeat.json` are reproducible generated outputs and are never the durable source of truth.",
   "last_session": {
-    "date": "2026-04-11",
-    "objective": "Take a thin follow-on slice on `#14` by adding one reusable markdown export path without widening the workflow surface.",
+    "date": "2026-04-11a",
+    "objective": "Harden one real multi-user request-boundary gap inside `#22` without widening the auth design.",
     "changes_made": [
-      "Confirmed the broader `#14` scope was already shipped locally in the roadmap, issue tracker, README, and demo gallery.",
-      "Added a shared `report.md` companion artifact for the endpoint-style workflows in `src/exa_demo/endpoint_workflows.py`.",
-      "Added `render_endpoint_report_markdown(...)` in `src/exa_demo/reporting.py` to generate stakeholder-friendly markdown for answer, research, structured-search, and find-similar runs.",
-      "Updated `README.md` and `docs/demo-gallery.md` so the reusable markdown export path is discoverable.",
-      "Added a new session log for the slice and synced the issue-tracker reference to it."
+      "Inspected the shipped pilot API auth layer in `src/exa_demo/api_auth.py` and the FastAPI boundary usage in `src/exa_demo/api.py`.",
+      "Confirmed the existing limiter keyed all requests by client IP, including authenticated multi-user traffic.",
+      "Added `_rate_limit_key(request)` so multi-user mode isolates rate-limit buckets per resolved authenticated user while single-key and no-auth modes keep the existing per-IP behavior.",
+      "Added focused coverage in `tests/test_api_auth.py` proving Alice and Bob do not consume each other's quota in multi-user mode.",
+      "Synced the local security doc and tracker/session pointers for the slice."
     ],
     "validation_run": [
-      "Ran `python -m pytest -q tests/test_reporting.py tests/test_workflows.py` and confirmed `13 passed`.",
-      "Ran `python -m ruff check src/exa_demo/reporting.py src/exa_demo/endpoint_workflows.py tests/test_reporting.py tests/test_workflows.py` and confirmed all checks passed."
+      "Ran `python -m pytest -q tests/test_api_auth.py` and confirmed `22 passed`.",
+      "Ran `python -m ruff check src/exa_demo/api_auth.py tests/test_api_auth.py` and confirmed all checks passed."
     ],
     "open_issues": [
-      "GitHub issue `#14` is still open even though the local roadmap/tracker already treat it as closed work.",
-      "This slice intentionally did not touch ranked-search/eval exports or pilot web-product work."
+      "GitHub issue tracking is still behind the local tracker for the current Phase 5 slices; `#22` exists only in repo docs today.",
+      "This slice intentionally did not change single-key/no-auth rate limiting, saved-query validation, or persistence behavior."
     ],
     "decisions_proposed": [
-      "Keep future export/report additions additive and artifact-first rather than changing existing JSON workflow contracts.",
-      "Treat any GitHub issue closure for `#14` as a repo-governance follow-up once the branch or PR is in place."
+      "Continue treating `#22` as a sequence of thin, evidence-backed request-boundary fixes rather than a single broad auth rewrite.",
+      "Prefer fixes that are directly tied to one inspected route or helper plus one focused regression test."
     ],
     "next_thin_slice": [
-      "Either close the GitHub-side `#14` issue with the corresponding PR, or move directly to `#22` pilot auth/request boundary controls for the next code session."
+      "Inspect one more request-boundary gap under `#22`, with saved-query input bounds or run-list pagination bounds as the best next candidates."
     ]
   },
   "next_thin_slice": [
-    "Either close the GitHub-side `#14` issue with the corresponding PR, or move directly to `#22` pilot auth/request boundary controls for the next code session."
+    "Inspect one more request-boundary gap under `#22`, with saved-query input bounds or run-list pagination bounds as the best next candidates."
   ]
 }

--- a/memory/2026-04-11a.md
+++ b/memory/2026-04-11a.md
@@ -1,0 +1,26 @@
+# Session Memory
+
+## Objective
+Harden one real multi-user request-boundary gap inside `#22` without widening the auth design.
+
+## Changes made
+- Inspected the shipped pilot API auth layer in `src/exa_demo/api_auth.py` and the FastAPI boundary usage in `src/exa_demo/api.py`.
+- Confirmed the existing limiter keyed all requests by client IP, including authenticated multi-user traffic.
+- Added `_rate_limit_key(request)` so multi-user mode isolates rate-limit buckets per resolved authenticated user while single-key and no-auth modes keep the existing per-IP behavior.
+- Added focused coverage in `tests/test_api_auth.py` proving Alice and Bob do not consume each other's quota in multi-user mode.
+- Synced the local security doc and tracker/session pointers for the slice.
+
+## Validation run
+- Ran `python -m pytest -q tests/test_api_auth.py` and confirmed `22 passed`.
+- Ran `python -m ruff check src/exa_demo/api_auth.py tests/test_api_auth.py` and confirmed all checks passed.
+
+## Open issues
+- GitHub issue tracking is still behind the local tracker for the current Phase 5 slices; `#22` exists only in repo docs today.
+- This slice intentionally did not change single-key/no-auth rate limiting, saved-query validation, or persistence behavior.
+
+## Decisions proposed
+- Continue treating `#22` as a sequence of thin, evidence-backed request-boundary fixes rather than a single broad auth rewrite.
+- Prefer fixes that are directly tied to one inspected route or helper plus one focused regression test.
+
+## Next thin slice
+- Inspect one more request-boundary gap under `#22`, with saved-query input bounds or run-list pagination bounds as the best next candidates.

--- a/src/exa_demo/api_auth.py
+++ b/src/exa_demo/api_auth.py
@@ -206,10 +206,26 @@ def _rate_limit_per_min() -> int:
 rate_limiter = RateLimiter(max_requests=_rate_limit_per_min())
 
 
+def _rate_limit_key(request: Request) -> str:
+    """Resolve the limiter bucket for the current request.
+
+    Multi-user mode should isolate quotas by authenticated user so one user's
+    traffic does not consume another user's allowance when both arrive from the
+    same client IP. Single-key and no-auth modes fall back to the existing
+    per-IP behavior.
+    """
+    if _pilot_users():
+        user_id = getattr(request.state, "user_id", "").strip()
+        if user_id:
+            return f"user:{user_id}"
+
+    client_host = request.client.host if request.client else "unknown"
+    return f"ip:{client_host}"
+
+
 def check_rate_limit(request: Request) -> None:
     """FastAPI dependency.  Enforces per-client rate limiting."""
-    client_key = request.client.host if request.client else "unknown"
-    allowed, remaining = rate_limiter.check(client_key)
+    allowed, remaining = rate_limiter.check(_rate_limit_key(request))
     if not allowed:
         raise HTTPException(
             status_code=429,

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -150,6 +150,36 @@ def test_rate_limit_enforced(auth_client, monkeypatch):
     assert "Retry-After" in resp.headers
 
 
+def test_rate_limit_isolated_per_user_in_multi_user_mode(
+    multi_user_client, monkeypatch
+):
+    """One multi-user client should not consume another user's bucket."""
+    monkeypatch.setattr(
+        auth_module, "rate_limiter", auth_module.RateLimiter(max_requests=1)
+    )
+
+    alice = multi_user_client.post(
+        "/api/search",
+        json={"query": "alice query", "mode": "smoke"},
+        headers={"Authorization": "Bearer key-alice"},
+    )
+    assert alice.status_code == 200
+
+    bob = multi_user_client.post(
+        "/api/search",
+        json={"query": "bob query", "mode": "smoke"},
+        headers={"Authorization": "Bearer key-bob"},
+    )
+    assert bob.status_code == 200
+
+    alice_again = multi_user_client.post(
+        "/api/search",
+        json={"query": "alice query", "mode": "smoke"},
+        headers={"Authorization": "Bearer key-alice"},
+    )
+    assert alice_again.status_code == 429
+
+
 # ---------------------------------------------------------------------------
 # Mode validation
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- isolate pilot API rate-limit buckets per authenticated user in multi-user mode
- preserve the existing per-IP limiter behavior for single-key and no-auth deployments
- sync the local security doc, issue tracker, session note, memory entry, and heartbeat sidecars for this thin `#22` slice

## Validation
- `python -m pytest -q tests/test_api_auth.py`
- `python -m ruff check src/exa_demo/api_auth.py tests/test_api_auth.py`

## Scope boundary
- no auth redesign
- no persistence changes
- no frontend or workflow behavior changes
