### PR TITLE
fix: bound saved-query inputs

### DIFF
--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -2,7 +2,7 @@
 
 _Generated file. Regenerate with `python scripts/generate_heartbeat.py`._
 
-_Generated: 2026-04-12T01:39:04.067897+00:00_
+_Generated: 2026-04-12T01:47:49.355039+00:00_
 
 ## Current status
 - Purpose: Exa-powered insurance intelligence toolkit for CAT-loss, claims, expert, contractor, and market/regulatory research workflows.
@@ -59,23 +59,23 @@ _Generated: 2026-04-12T01:39:04.067897+00:00_
 - Scope beyond this scaffold into auth redesign, persistence implementation, async jobs, deployment, infra, or broader docs refactors.
 
 ## Last session
-- Date: 2026-04-11a
-- Objective: Harden one real multi-user request-boundary gap inside `#22` without widening the auth design.
+- Date: 2026-04-11b
+- Objective: Harden one more request-boundary gap inside `#22` by tightening saved-query creation without broadening the pilot surface.
 - Changes made:
-  - Inspected the shipped pilot API auth layer in `src/exa_demo/api_auth.py` and the FastAPI boundary usage in `src/exa_demo/api.py`.
-  - Confirmed the existing limiter keyed all requests by client IP, including authenticated multi-user traffic.
-  - Added `_rate_limit_key(request)` so multi-user mode isolates rate-limit buckets per resolved authenticated user while single-key and no-auth modes keep the existing per-IP behavior.
-  - Added focused coverage in `tests/test_api_auth.py` proving Alice and Bob do not consume each other's quota in multi-user mode.
-  - Synced the local security doc and tracker/session pointers for the slice.
+  - Inspected `POST /api/me/saved-queries` in `src/exa_demo/api.py` and confirmed the route persisted raw input with no saved-query-specific validation.
+  - Confirmed the existing pilot query-length guard already lived in `src/exa_demo/api_auth.py` and that the shipped frontend only offered saved-query creation for `search`, `answer`, and `research`.
+  - Added a saved-query workflow allowlist for the currently shipped pilot surfaces and reused `validate_query(...)` for saved-query writes.
+  - Added focused saved-query regression coverage in `tests/test_users.py` for invalid workflow and overlong query rejections.
+  - Synced the security doc and tracker/session pointers for this slice.
 - Validation:
-  - Ran `python -m pytest -q tests/test_api_auth.py` and confirmed `22 passed`.
-  - Ran `python -m ruff check src/exa_demo/api_auth.py tests/test_api_auth.py` and confirmed all checks passed.
+  - Ran `python -m pytest -q tests/test_users.py` and confirmed `26 passed`.
+  - Ran `python -m ruff check src/exa_demo/api.py tests/test_users.py` and confirmed all checks passed.
 - Open issues:
-  - GitHub issue tracking is still behind the local tracker for the current Phase 5 slices; `#22` exists only in repo docs today.
-  - This slice intentionally did not change single-key/no-auth rate limiting, saved-query validation, or persistence behavior.
+  - This slice intentionally did not add label bounds because the repo does not yet have a documented or shipped label contract for saved queries.
+  - Run-list pagination and other request-boundary tightening under `#22` are still open.
 - Decisions proposed:
-  - Continue treating `#22` as a sequence of thin, evidence-backed request-boundary fixes rather than a single broad auth rewrite.
-  - Prefer fixes that are directly tied to one inspected route or helper plus one focused regression test.
+  - Keep `#22` moving via one inspected route or helper at a time, with regression coverage attached to each narrow fix.
+  - Treat saved-query workflow acceptance as a pilot-surface boundary, not as a generic storage field that should accept every backend workflow by default.
 
 ## Next thin slice
-- Inspect one more request-boundary gap under `#22`, with saved-query input bounds or run-list pagination bounds as the best next candidates.
+- Add narrow pagination bounds for `/api/me/runs` and `/api/runs` so negative or pathological values cannot create odd behavior.

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -44,7 +44,7 @@ Update it whenever issues are created, closed, re-scoped, or moved between miles
 | `#19 Epic: Pilot web product layer` | Epic | `Phase 5 - Pilot` | `type:epic`, `area:pilot`, `priority:p0`, `status:ready` | Open | Phases 1-4 | Phase 5 - Pilot Web Product | TBD | `docs/sessions/2026-03-22-pilot-alignment.md` |
 | `#20 Thin FastAPI wrapper over existing workflows` | Task | `Phase 5 - Pilot` | `type:task`, `area:api`, `priority:p0`, `status:done` | Done | `#19` | Phase 5 Level 1 | TBD | `docs/sessions/2026-03-22-api-wrapper.md` |
 | `#21 Frontend app shell (Next.js + Tailwind + shadcn/ui)` | Task | `Phase 5 - Pilot` | `type:task`, `area:frontend`, `priority:p0`, `status:done` | Done | `#19, #20` | Phase 5 Level 1 | TBD | `docs/sessions/2026-03-22-frontend-shell.md` |
-| `#22 Pilot auth + request/budget boundary controls` | Task | `Phase 5 - Pilot` | `type:task`, `area:auth`, `priority:p0`, `status:next` | Next | `#19, #20` | Phase 5 Level 1 | TBD | `docs/sessions/2026-04-11-issue-22-rate-limit-scope.md` |
+| `#22 Pilot auth + request/budget boundary controls` | Task | `Phase 5 - Pilot` | `type:task`, `area:auth`, `priority:p0`, `status:next` | Next | `#19, #20` | Phase 5 Level 1 | TBD | `docs/sessions/2026-04-11-issue-22-saved-query-bounds.md` |
 | `#23 Persistence/state baseline (S3 artifacts + Postgres usage)` | Task | `Phase 5 - Pilot` | `type:task`, `area:infra`, `priority:p1`, `status:next` | Next | `#19, #20` | Phase 5 Level 1 | TBD | `docs/sessions/2026-03-22-pilot-alignment.md` |
 
 ### Next Coding Slices (Sequenced)
@@ -64,5 +64,4 @@ Each slice should be one focused agent session. See [agent-execution-defaults.md
 - Close the roadmap item and issue together, or document why they diverged.
 - Update the `Last-updated session log` field whenever the issue scope, status, or acceptance criteria changes.
 - Record durable process changes in `docs/adr/`.
-
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -52,8 +52,9 @@ Install with: `pre-commit install`
 - Live mode gated behind `PILOT_ALLOW_LIVE_MODE=1`
 
 ### Input Validation
-- Query length bounded (`PILOT_MAX_QUERY_LENGTH`, default 1000 chars)
+- Query length bounded (`PILOT_MAX_QUERY_LENGTH`, default 1000 chars), including saved-query writes
 - Result count clamped (`PILOT_MAX_RESULTS`, default 25)
+- Saved-query workflows limited to the currently shipped pilot surfaces (`search`, `answer`, `research`)
 - Pydantic model validation on all API request bodies
 - Request ID tracking via `X-Request-ID` header
 

--- a/docs/sessions/2026-04-11-issue-22-saved-query-bounds.md
+++ b/docs/sessions/2026-04-11-issue-22-saved-query-bounds.md
@@ -1,0 +1,50 @@
+# Session: Issue 22 saved-query bounds
+
+- Date: 2026-04-11
+- Participants: Codex, user
+- Related roadmap items: `#22`, `#17`
+- Related ADRs: none
+
+## Context
+
+Continue `#22` with one narrow request-boundary slice by inspecting the saved-query write path and adding only the missing input bounds that were already justified by shipped pilot behavior.
+
+## Repo Facts Observed
+
+- `src/exa_demo/api.py` exposed `POST /api/me/saved-queries` with raw `workflow`, `query`, and `label` fields and persisted them directly.
+- `src/exa_demo/api_auth.py` already shipped `validate_query(...)` for the same pilot-wide query-length guard used by other request bodies.
+- The current pilot frontend only offers saved-query creation for `search`, `answer`, and `research`, so broader workflow acceptance would widen surface area beyond the shipped UI.
+- `tests/test_users.py` covered saved-query CRUD and ownership, but it did not assert any input-boundary behavior for saved-query creation.
+
+## Decisions Made
+
+- Reuse the existing pilot query-length guard for saved-query writes instead of introducing a second length policy.
+- Limit saved-query workflow values to the currently shipped pilot surfaces: `search`, `answer`, and `research`.
+- Do not introduce a new label policy in this slice because the repo had no prior documented or shipped label contract to harden against.
+
+## Issues Opened or Updated
+
+- `#22 Pilot auth + request/budget boundary controls` - advanced with saved-query workflow and query-length validation, and updated local tracker/session pointers.
+- `#17 Maintain roadmap, issue tracker, ADRs, and session notes` - updated indirectly through the required session/memory/heartbeat sync.
+
+## Docs Touched
+
+- `docs/security.md`
+- `docs/issue-tracker.md`
+- `docs/sessions/2026-04-11-issue-22-saved-query-bounds.md`
+
+## Tests and Checks Run
+
+- `python -m pytest -q tests/test_users.py` -> passed (`26 passed`)
+- `python -m ruff check src/exa_demo/api.py tests/test_users.py` -> passed
+
+## Outcome
+
+- Hardened `POST /api/me/saved-queries` so saved-query writes now reject unsupported workflow names and reuse the existing pilot query-length bound.
+- Added focused regression coverage for both failure paths without changing the existing CRUD or ownership behavior.
+- Kept the slice limited to one inspected route and one small documentation correction.
+
+## Next-Session Handoff
+
+- Continue `#22` with another thin request-boundary fix, with run-list pagination bounds as the best next candidate.
+- Keep persistence (`#23`) deferred until the request/auth boundary work is sufficiently tightened.

--- a/heartbeat.json
+++ b/heartbeat.json
@@ -1,6 +1,6 @@
 {
   "repo": "exai-insurance-intel",
-  "generated_at": "2026-04-12T01:39:04.067897+00:00",
+  "generated_at": "2026-04-12T01:47:49.355039+00:00",
   "purpose": "Exa-powered insurance intelligence toolkit for CAT-loss, claims, expert, contractor, and market/regulatory research workflows.",
   "strategic_role": "Workflow engine plus controlled pilot web-product base for internal insurance-intelligence validation.",
   "current_milestone": "Phase 5 Level 1 is partially complete: the thin FastAPI wrapper and frontend shell are shipped, while pilot auth/request controls and persistence baseline remain the next bounded slices.",
@@ -51,32 +51,32 @@
   ],
   "update_policy": "`MEMORY.md` stays curated and human-reviewed. `memory/YYYY-MM-DD.md` stays append-only. `HEARTBEAT.md` and `heartbeat.json` are reproducible generated outputs and are never the durable source of truth.",
   "last_session": {
-    "date": "2026-04-11a",
-    "objective": "Harden one real multi-user request-boundary gap inside `#22` without widening the auth design.",
+    "date": "2026-04-11b",
+    "objective": "Harden one more request-boundary gap inside `#22` by tightening saved-query creation without broadening the pilot surface.",
     "changes_made": [
-      "Inspected the shipped pilot API auth layer in `src/exa_demo/api_auth.py` and the FastAPI boundary usage in `src/exa_demo/api.py`.",
-      "Confirmed the existing limiter keyed all requests by client IP, including authenticated multi-user traffic.",
-      "Added `_rate_limit_key(request)` so multi-user mode isolates rate-limit buckets per resolved authenticated user while single-key and no-auth modes keep the existing per-IP behavior.",
-      "Added focused coverage in `tests/test_api_auth.py` proving Alice and Bob do not consume each other's quota in multi-user mode.",
-      "Synced the local security doc and tracker/session pointers for the slice."
+      "Inspected `POST /api/me/saved-queries` in `src/exa_demo/api.py` and confirmed the route persisted raw input with no saved-query-specific validation.",
+      "Confirmed the existing pilot query-length guard already lived in `src/exa_demo/api_auth.py` and that the shipped frontend only offered saved-query creation for `search`, `answer`, and `research`.",
+      "Added a saved-query workflow allowlist for the currently shipped pilot surfaces and reused `validate_query(...)` for saved-query writes.",
+      "Added focused saved-query regression coverage in `tests/test_users.py` for invalid workflow and overlong query rejections.",
+      "Synced the security doc and tracker/session pointers for this slice."
     ],
     "validation_run": [
-      "Ran `python -m pytest -q tests/test_api_auth.py` and confirmed `22 passed`.",
-      "Ran `python -m ruff check src/exa_demo/api_auth.py tests/test_api_auth.py` and confirmed all checks passed."
+      "Ran `python -m pytest -q tests/test_users.py` and confirmed `26 passed`.",
+      "Ran `python -m ruff check src/exa_demo/api.py tests/test_users.py` and confirmed all checks passed."
     ],
     "open_issues": [
-      "GitHub issue tracking is still behind the local tracker for the current Phase 5 slices; `#22` exists only in repo docs today.",
-      "This slice intentionally did not change single-key/no-auth rate limiting, saved-query validation, or persistence behavior."
+      "This slice intentionally did not add label bounds because the repo does not yet have a documented or shipped label contract for saved queries.",
+      "Run-list pagination and other request-boundary tightening under `#22` are still open."
     ],
     "decisions_proposed": [
-      "Continue treating `#22` as a sequence of thin, evidence-backed request-boundary fixes rather than a single broad auth rewrite.",
-      "Prefer fixes that are directly tied to one inspected route or helper plus one focused regression test."
+      "Keep `#22` moving via one inspected route or helper at a time, with regression coverage attached to each narrow fix.",
+      "Treat saved-query workflow acceptance as a pilot-surface boundary, not as a generic storage field that should accept every backend workflow by default."
     ],
     "next_thin_slice": [
-      "Inspect one more request-boundary gap under `#22`, with saved-query input bounds or run-list pagination bounds as the best next candidates."
+      "Add narrow pagination bounds for `/api/me/runs` and `/api/runs` so negative or pathological values cannot create odd behavior."
     ]
   },
   "next_thin_slice": [
-    "Inspect one more request-boundary gap under `#22`, with saved-query input bounds or run-list pagination bounds as the best next candidates."
+    "Add narrow pagination bounds for `/api/me/runs` and `/api/runs` so negative or pathological values cannot create odd behavior."
   ]
 }

--- a/memory/2026-04-11b.md
+++ b/memory/2026-04-11b.md
@@ -1,0 +1,26 @@
+# Session Memory
+
+## Objective
+Harden one more request-boundary gap inside `#22` by tightening saved-query creation without broadening the pilot surface.
+
+## Changes made
+- Inspected `POST /api/me/saved-queries` in `src/exa_demo/api.py` and confirmed the route persisted raw input with no saved-query-specific validation.
+- Confirmed the existing pilot query-length guard already lived in `src/exa_demo/api_auth.py` and that the shipped frontend only offered saved-query creation for `search`, `answer`, and `research`.
+- Added a saved-query workflow allowlist for the currently shipped pilot surfaces and reused `validate_query(...)` for saved-query writes.
+- Added focused saved-query regression coverage in `tests/test_users.py` for invalid workflow and overlong query rejections.
+- Synced the security doc and tracker/session pointers for this slice.
+
+## Validation run
+- Ran `python -m pytest -q tests/test_users.py` and confirmed `26 passed`.
+- Ran `python -m ruff check src/exa_demo/api.py tests/test_users.py` and confirmed all checks passed.
+
+## Open issues
+- This slice intentionally did not add label bounds because the repo does not yet have a documented or shipped label contract for saved queries.
+- Run-list pagination and other request-boundary tightening under `#22` are still open.
+
+## Decisions proposed
+- Keep `#22` moving via one inspected route or helper at a time, with regression coverage attached to each narrow fix.
+- Treat saved-query workflow acceptance as a pilot-surface boundary, not as a generic storage field that should accept every backend workflow by default.
+
+## Next thin slice
+- Add narrow pagination bounds for `/api/me/runs` and `/api/runs` so negative or pathological values cannot create odd behavior.

--- a/src/exa_demo/api.py
+++ b/src/exa_demo/api.py
@@ -57,6 +57,8 @@ from .ranked_workflows import run_search_workflow
 
 logger = logging.getLogger("exa_demo.api")
 
+SAVED_QUERY_WORKFLOWS = frozenset({"search", "answer", "research"})
+
 app = FastAPI(
     title="exai-insurance-intel API",
     description="Thin API wrapper over existing insurance intelligence workflows.",
@@ -731,10 +733,12 @@ def api_save_query(
     req: SavedQueryRequest, request: Request
 ) -> Dict[str, Any]:
     uid = get_current_user(request)
+    workflow = _validate_saved_query_workflow(req.workflow)
+    query = validate_query(req.query)
     sq = SavedQuery(
         user_id=uid,
-        workflow=req.workflow,
-        query=req.query,
+        workflow=workflow,
+        query=query,
         label=req.label,
         created_at=_utc_now(),
     )
@@ -818,6 +822,17 @@ def _job_to_dict(record) -> Dict[str, Any]:  # type: ignore[no-untyped-def]
         result = record.extra.get("result")
     payload["result"] = result
     return payload
+
+
+def _validate_saved_query_workflow(workflow: str) -> str:
+    normalized = workflow.strip()
+    if normalized not in SAVED_QUERY_WORKFLOWS:
+        allowed = ", ".join(sorted(SAVED_QUERY_WORKFLOWS))
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid saved-query workflow '{workflow}'. Must be one of: {allowed}",
+        )
+    return normalized
 
 
 app.include_router(api_router)

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -290,6 +290,24 @@ class TestSavedQueries:
         assert data["count"] == 1
         assert data["queries"][0]["id"] == sq["id"]
 
+    def test_rejects_invalid_saved_query_workflow(self, multi_user_client):
+        resp = multi_user_client.post(
+            "/api/me/saved-queries",
+            json={"workflow": "unsupported-workflow", "query": "Florida CAT market"},
+            headers={"Authorization": "Bearer key-alice"},
+        )
+        assert resp.status_code == 400
+        assert "Invalid saved-query workflow" in resp.json()["detail"]
+
+    def test_rejects_saved_query_longer_than_pilot_limit(self, multi_user_client):
+        resp = multi_user_client.post(
+            "/api/me/saved-queries",
+            json={"workflow": "search", "query": "x" * 1001},
+            headers={"Authorization": "Bearer key-alice"},
+        )
+        assert resp.status_code == 400
+        assert "Query too long" in resp.json()["detail"]
+
     def test_delete_saved_query(self, multi_user_client):
         # Create.
         resp = multi_user_client.post(


### PR DESCRIPTION
## Summary
- bound saved-query creation to the currently shipped pilot workflows (search, nswer, esearch)
- reuse the existing pilot query-length validator for saved-query writes
- add focused saved-query regression coverage and sync the local session/tracker docs

## Validation
- python -m pytest -q tests/test_users.py
- python -m ruff check src/exa_demo/api.py tests/test_users.py