### PR TITLE
fix: bound run pagination inputs

### DIFF
--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -2,7 +2,7 @@
 
 _Generated file. Regenerate with `python scripts/generate_heartbeat.py`._
 
-_Generated: 2026-04-12T01:47:49.355039+00:00_
+_Generated: 2026-04-12T01:58:27.133516+00:00_
 
 ## Current status
 - Purpose: Exa-powered insurance intelligence toolkit for CAT-loss, claims, expert, contractor, and market/regulatory research workflows.
@@ -59,23 +59,24 @@ _Generated: 2026-04-12T01:47:49.355039+00:00_
 - Scope beyond this scaffold into auth redesign, persistence implementation, async jobs, deployment, infra, or broader docs refactors.
 
 ## Last session
-- Date: 2026-04-11b
-- Objective: Harden one more request-boundary gap inside `#22` by tightening saved-query creation without broadening the pilot surface.
+- Date: 2026-04-11c
+- Objective: Harden one more request-boundary gap inside `#22` by validating run-list pagination before repository queries execute.
 - Changes made:
-  - Inspected `POST /api/me/saved-queries` in `src/exa_demo/api.py` and confirmed the route persisted raw input with no saved-query-specific validation.
-  - Confirmed the existing pilot query-length guard already lived in `src/exa_demo/api_auth.py` and that the shipped frontend only offered saved-query creation for `search`, `answer`, and `research`.
-  - Added a saved-query workflow allowlist for the currently shipped pilot surfaces and reused `validate_query(...)` for saved-query writes.
-  - Added focused saved-query regression coverage in `tests/test_users.py` for invalid workflow and overlong query rejections.
+  - Inspected `/api/me/runs` and `/api/runs` in `src/exa_demo/api.py` and confirmed both routes only capped large limits while still accepting negative pagination values.
+  - Confirmed `src/exa_demo/persistence.py` used the incoming pagination values directly in SQL `LIMIT` and `OFFSET` clauses across the repository adapters.
+  - Added `validate_pagination(...)` in `src/exa_demo/api_auth.py` to reject non-positive limits and negative offsets while preserving the existing 200-item cap.
+  - Applied the shared pagination validator to both run-list routes in `src/exa_demo/api.py`.
+  - Added focused regression coverage in `tests/test_persistence.py` and `tests/test_users.py` for invalid ops/global and per-user pagination inputs.
   - Synced the security doc and tracker/session pointers for this slice.
 - Validation:
-  - Ran `python -m pytest -q tests/test_users.py` and confirmed `26 passed`.
-  - Ran `python -m ruff check src/exa_demo/api.py tests/test_users.py` and confirmed all checks passed.
+  - Ran `python -m pytest -q tests/test_persistence.py tests/test_users.py` and confirmed `66 passed`.
+  - Ran `python -m ruff check src/exa_demo/api.py src/exa_demo/api_auth.py tests/test_persistence.py tests/test_users.py` and confirmed all checks passed.
 - Open issues:
-  - This slice intentionally did not add label bounds because the repo does not yet have a documented or shipped label contract for saved queries.
-  - Run-list pagination and other request-boundary tightening under `#22` are still open.
+  - This slice intentionally preserved the existing oversized-limit cap semantics instead of redesigning pagination or response metadata.
+  - The repo still has no concrete shipped contract for saved-query label bounds, so that remains a weak candidate for more `#22` work.
 - Decisions proposed:
-  - Keep `#22` moving via one inspected route or helper at a time, with regression coverage attached to each narrow fix.
-  - Treat saved-query workflow acceptance as a pilot-surface boundary, not as a generic storage field that should accept every backend workflow by default.
+  - Continue to centralize request-boundary helpers in `api_auth.py` when they apply across multiple FastAPI routes.
+  - Treat future `#22` slices as complete only when they map to one inspected route or helper plus focused regression coverage.
 
 ## Next thin slice
-- Add narrow pagination bounds for `/api/me/runs` and `/api/runs` so negative or pathological values cannot create odd behavior.
+- Reassess whether another evidence-backed `#22` gap still exists; if not, move to the first thin `#23` persistence baseline slice.

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -44,7 +44,7 @@ Update it whenever issues are created, closed, re-scoped, or moved between miles
 | `#19 Epic: Pilot web product layer` | Epic | `Phase 5 - Pilot` | `type:epic`, `area:pilot`, `priority:p0`, `status:ready` | Open | Phases 1-4 | Phase 5 - Pilot Web Product | TBD | `docs/sessions/2026-03-22-pilot-alignment.md` |
 | `#20 Thin FastAPI wrapper over existing workflows` | Task | `Phase 5 - Pilot` | `type:task`, `area:api`, `priority:p0`, `status:done` | Done | `#19` | Phase 5 Level 1 | TBD | `docs/sessions/2026-03-22-api-wrapper.md` |
 | `#21 Frontend app shell (Next.js + Tailwind + shadcn/ui)` | Task | `Phase 5 - Pilot` | `type:task`, `area:frontend`, `priority:p0`, `status:done` | Done | `#19, #20` | Phase 5 Level 1 | TBD | `docs/sessions/2026-03-22-frontend-shell.md` |
-| `#22 Pilot auth + request/budget boundary controls` | Task | `Phase 5 - Pilot` | `type:task`, `area:auth`, `priority:p0`, `status:next` | Next | `#19, #20` | Phase 5 Level 1 | TBD | `docs/sessions/2026-04-11-issue-22-saved-query-bounds.md` |
+| `#22 Pilot auth + request/budget boundary controls` | Task | `Phase 5 - Pilot` | `type:task`, `area:auth`, `priority:p0`, `status:next` | Next | `#19, #20` | Phase 5 Level 1 | TBD | `docs/sessions/2026-04-11-issue-22-run-pagination-bounds.md` |
 | `#23 Persistence/state baseline (S3 artifacts + Postgres usage)` | Task | `Phase 5 - Pilot` | `type:task`, `area:infra`, `priority:p1`, `status:next` | Next | `#19, #20` | Phase 5 Level 1 | TBD | `docs/sessions/2026-03-22-pilot-alignment.md` |
 
 ### Next Coding Slices (Sequenced)
@@ -64,4 +64,3 @@ Each slice should be one focused agent session. See [agent-execution-defaults.md
 - Close the roadmap item and issue together, or document why they diverged.
 - Update the `Last-updated session log` field whenever the issue scope, status, or acceptance criteria changes.
 - Record durable process changes in `docs/adr/`.
-

--- a/docs/security.md
+++ b/docs/security.md
@@ -55,6 +55,7 @@ Install with: `pre-commit install`
 - Query length bounded (`PILOT_MAX_QUERY_LENGTH`, default 1000 chars), including saved-query writes
 - Result count clamped (`PILOT_MAX_RESULTS`, default 25)
 - Saved-query workflows limited to the currently shipped pilot surfaces (`search`, `answer`, `research`)
+- Run-list pagination rejects negative offsets and non-positive limits, while still capping oversized limits at 200
 - Pydantic model validation on all API request bodies
 - Request ID tracking via `X-Request-ID` header
 

--- a/docs/sessions/2026-04-11-issue-22-run-pagination-bounds.md
+++ b/docs/sessions/2026-04-11-issue-22-run-pagination-bounds.md
@@ -1,0 +1,50 @@
+# Session: Issue 22 run pagination bounds
+
+- Date: 2026-04-11
+- Participants: Codex, user
+- Related roadmap items: `#22`, `#17`
+- Related ADRs: none
+
+## Context
+
+Continue `#22` with one more narrow request-boundary slice by inspecting the run-list endpoints and hardening only the pagination inputs that were still flowing unchecked into the repository layer.
+
+## Repo Facts Observed
+
+- `src/exa_demo/api.py` exposed both `/api/me/runs` and `/api/runs` with raw integer `limit` and `offset` query params.
+- The current route logic already capped large `limit` values at `200`, but it passed negative `limit` and `offset` values through unchanged.
+- `src/exa_demo/persistence.py` used those values directly in `LIMIT` and `OFFSET` clauses for both SQLite and Postgres repository adapters.
+- Existing tests covered happy-path pagination and ownership, but they did not assert any behavior for invalid pagination inputs.
+
+## Decisions Made
+
+- Keep the existing oversized-limit cap at `200` instead of redesigning pagination semantics.
+- Reject non-positive `limit` values and negative `offset` values with `400` responses before the repository layer sees them.
+- Reuse one shared validation helper for both run-list routes so the bounds stay aligned across owner and ops views.
+
+## Issues Opened or Updated
+
+- `#22 Pilot auth + request/budget boundary controls` - advanced with shared run-list pagination validation and updated local tracker/session pointers.
+- `#17 Maintain roadmap, issue tracker, ADRs, and session notes` - updated indirectly through the required session/memory/heartbeat sync.
+
+## Docs Touched
+
+- `docs/security.md`
+- `docs/issue-tracker.md`
+- `docs/sessions/2026-04-11-issue-22-run-pagination-bounds.md`
+
+## Tests and Checks Run
+
+- `python -m pytest -q tests/test_persistence.py tests/test_users.py` -> passed (`66 passed`)
+- `python -m ruff check src/exa_demo/api.py src/exa_demo/api_auth.py tests/test_persistence.py tests/test_users.py` -> passed
+
+## Outcome
+
+- Hardened `/api/me/runs` and `/api/runs` so invalid pagination values now fail fast with `400` responses instead of reaching the persistence layer.
+- Preserved the existing `limit <= 200` cap and all existing happy-path pagination behavior.
+- Added focused regression coverage for both the ops-global route and the per-user route.
+
+## Next-Session Handoff
+
+- Continue `#22` with another thin boundary slice, with saved-query label bounds or filter allowlists only if a concrete shipped contract appears.
+- Otherwise, the next stronger candidate is to stop the auth/request track and move to `#23` persistence baseline once the remaining boundary gaps no longer have clear evidence.

--- a/heartbeat.json
+++ b/heartbeat.json
@@ -1,6 +1,6 @@
 {
   "repo": "exai-insurance-intel",
-  "generated_at": "2026-04-12T01:47:49.355039+00:00",
+  "generated_at": "2026-04-12T01:58:27.133516+00:00",
   "purpose": "Exa-powered insurance intelligence toolkit for CAT-loss, claims, expert, contractor, and market/regulatory research workflows.",
   "strategic_role": "Workflow engine plus controlled pilot web-product base for internal insurance-intelligence validation.",
   "current_milestone": "Phase 5 Level 1 is partially complete: the thin FastAPI wrapper and frontend shell are shipped, while pilot auth/request controls and persistence baseline remain the next bounded slices.",
@@ -51,32 +51,33 @@
   ],
   "update_policy": "`MEMORY.md` stays curated and human-reviewed. `memory/YYYY-MM-DD.md` stays append-only. `HEARTBEAT.md` and `heartbeat.json` are reproducible generated outputs and are never the durable source of truth.",
   "last_session": {
-    "date": "2026-04-11b",
-    "objective": "Harden one more request-boundary gap inside `#22` by tightening saved-query creation without broadening the pilot surface.",
+    "date": "2026-04-11c",
+    "objective": "Harden one more request-boundary gap inside `#22` by validating run-list pagination before repository queries execute.",
     "changes_made": [
-      "Inspected `POST /api/me/saved-queries` in `src/exa_demo/api.py` and confirmed the route persisted raw input with no saved-query-specific validation.",
-      "Confirmed the existing pilot query-length guard already lived in `src/exa_demo/api_auth.py` and that the shipped frontend only offered saved-query creation for `search`, `answer`, and `research`.",
-      "Added a saved-query workflow allowlist for the currently shipped pilot surfaces and reused `validate_query(...)` for saved-query writes.",
-      "Added focused saved-query regression coverage in `tests/test_users.py` for invalid workflow and overlong query rejections.",
+      "Inspected `/api/me/runs` and `/api/runs` in `src/exa_demo/api.py` and confirmed both routes only capped large limits while still accepting negative pagination values.",
+      "Confirmed `src/exa_demo/persistence.py` used the incoming pagination values directly in SQL `LIMIT` and `OFFSET` clauses across the repository adapters.",
+      "Added `validate_pagination(...)` in `src/exa_demo/api_auth.py` to reject non-positive limits and negative offsets while preserving the existing 200-item cap.",
+      "Applied the shared pagination validator to both run-list routes in `src/exa_demo/api.py`.",
+      "Added focused regression coverage in `tests/test_persistence.py` and `tests/test_users.py` for invalid ops/global and per-user pagination inputs.",
       "Synced the security doc and tracker/session pointers for this slice."
     ],
     "validation_run": [
-      "Ran `python -m pytest -q tests/test_users.py` and confirmed `26 passed`.",
-      "Ran `python -m ruff check src/exa_demo/api.py tests/test_users.py` and confirmed all checks passed."
+      "Ran `python -m pytest -q tests/test_persistence.py tests/test_users.py` and confirmed `66 passed`.",
+      "Ran `python -m ruff check src/exa_demo/api.py src/exa_demo/api_auth.py tests/test_persistence.py tests/test_users.py` and confirmed all checks passed."
     ],
     "open_issues": [
-      "This slice intentionally did not add label bounds because the repo does not yet have a documented or shipped label contract for saved queries.",
-      "Run-list pagination and other request-boundary tightening under `#22` are still open."
+      "This slice intentionally preserved the existing oversized-limit cap semantics instead of redesigning pagination or response metadata.",
+      "The repo still has no concrete shipped contract for saved-query label bounds, so that remains a weak candidate for more `#22` work."
     ],
     "decisions_proposed": [
-      "Keep `#22` moving via one inspected route or helper at a time, with regression coverage attached to each narrow fix.",
-      "Treat saved-query workflow acceptance as a pilot-surface boundary, not as a generic storage field that should accept every backend workflow by default."
+      "Continue to centralize request-boundary helpers in `api_auth.py` when they apply across multiple FastAPI routes.",
+      "Treat future `#22` slices as complete only when they map to one inspected route or helper plus focused regression coverage."
     ],
     "next_thin_slice": [
-      "Add narrow pagination bounds for `/api/me/runs` and `/api/runs` so negative or pathological values cannot create odd behavior."
+      "Reassess whether another evidence-backed `#22` gap still exists; if not, move to the first thin `#23` persistence baseline slice."
     ]
   },
   "next_thin_slice": [
-    "Add narrow pagination bounds for `/api/me/runs` and `/api/runs` so negative or pathological values cannot create odd behavior."
+    "Reassess whether another evidence-backed `#22` gap still exists; if not, move to the first thin `#23` persistence baseline slice."
   ]
 }

--- a/memory/2026-04-11c.md
+++ b/memory/2026-04-11c.md
@@ -1,0 +1,27 @@
+# Session Memory
+
+## Objective
+Harden one more request-boundary gap inside `#22` by validating run-list pagination before repository queries execute.
+
+## Changes made
+- Inspected `/api/me/runs` and `/api/runs` in `src/exa_demo/api.py` and confirmed both routes only capped large limits while still accepting negative pagination values.
+- Confirmed `src/exa_demo/persistence.py` used the incoming pagination values directly in SQL `LIMIT` and `OFFSET` clauses across the repository adapters.
+- Added `validate_pagination(...)` in `src/exa_demo/api_auth.py` to reject non-positive limits and negative offsets while preserving the existing 200-item cap.
+- Applied the shared pagination validator to both run-list routes in `src/exa_demo/api.py`.
+- Added focused regression coverage in `tests/test_persistence.py` and `tests/test_users.py` for invalid ops/global and per-user pagination inputs.
+- Synced the security doc and tracker/session pointers for this slice.
+
+## Validation run
+- Ran `python -m pytest -q tests/test_persistence.py tests/test_users.py` and confirmed `66 passed`.
+- Ran `python -m ruff check src/exa_demo/api.py src/exa_demo/api_auth.py tests/test_persistence.py tests/test_users.py` and confirmed all checks passed.
+
+## Open issues
+- This slice intentionally preserved the existing oversized-limit cap semantics instead of redesigning pagination or response metadata.
+- The repo still has no concrete shipped contract for saved-query label bounds, so that remains a weak candidate for more `#22` work.
+
+## Decisions proposed
+- Continue to centralize request-boundary helpers in `api_auth.py` when they apply across multiple FastAPI routes.
+- Treat future `#22` slices as complete only when they map to one inspected route or helper plus focused regression coverage.
+
+## Next thin slice
+- Reassess whether another evidence-backed `#22` gap still exists; if not, move to the first thin `#23` persistence baseline slice.

--- a/src/exa_demo/api.py
+++ b/src/exa_demo/api.py
@@ -35,6 +35,7 @@ from .api_auth import (
     require_api_key,
     user_can_access_ops,
     validate_mode,
+    validate_pagination,
     validate_query,
 )
 from .cli_runtime import resolve_runtime, runtime_metadata
@@ -690,10 +691,10 @@ def api_my_runs(
 ) -> Dict[str, Any]:
     """List runs belonging to the current user."""
     uid = get_current_user(request)
-    capped_limit = min(limit, 200)
+    capped_limit, validated_offset = validate_pagination(limit, offset)
     runs = run_repo.list_runs(
         limit=capped_limit,
-        offset=offset,
+        offset=validated_offset,
         workflow=workflow,
         status=status,
         user_id=uid,
@@ -776,10 +777,10 @@ def api_list_runs(
     status: Optional[str] = None,
 ) -> Dict[str, Any]:
     require_ops_access(request)
-    capped_limit = min(limit, 200)
+    capped_limit, validated_offset = validate_pagination(limit, offset)
     runs = run_repo.list_runs(
         limit=capped_limit,
-        offset=offset,
+        offset=validated_offset,
         workflow=workflow,
         mode=mode,
         status=status,

--- a/src/exa_demo/api_auth.py
+++ b/src/exa_demo/api_auth.py
@@ -289,6 +289,26 @@ def clamp_num_results(num_results: int) -> int:
     return min(num_results, _pilot_max_results())
 
 
+def validate_pagination(
+    limit: int,
+    offset: int,
+    *,
+    max_limit: int = 200,
+) -> tuple[int, int]:
+    """Raise 400 for invalid pagination and clamp large limits."""
+    if limit < 1:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid limit '{limit}'. Must be at least 1.",
+        )
+    if offset < 0:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid offset '{offset}'. Must be 0 or greater.",
+        )
+    return min(limit, max_limit), offset
+
+
 # ---------------------------------------------------------------------------
 # Request-logging middleware
 # ---------------------------------------------------------------------------

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -365,6 +365,21 @@ def test_runs_list_pagination(client):
     assert data2["count"] == 1
 
 
+def test_runs_list_rejects_negative_pagination(client):
+    for i in range(2):
+        client.post(
+            "/api/search", json={"query": f"query {i}", "mode": "smoke"}
+        )
+
+    resp = client.get("/api/runs?limit=-1&offset=0")
+    assert resp.status_code == 400
+    assert "Invalid limit" in resp.json()["detail"]
+
+    resp = client.get("/api/runs?limit=2&offset=-1")
+    assert resp.status_code == 400
+    assert "Invalid offset" in resp.json()["detail"]
+
+
 def test_answer_persists_run(client):
     client.post(
         "/api/answer",

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -215,6 +215,27 @@ class TestRunOwnership:
         )
         assert resp.status_code == 403
 
+    def test_my_runs_rejects_negative_pagination(self, multi_user_client):
+        multi_user_client.post(
+            "/api/search",
+            json={"query": "alice query", "mode": "smoke"},
+            headers={"Authorization": "Bearer key-alice"},
+        )
+
+        resp = multi_user_client.get(
+            "/api/me/runs?limit=-1&offset=0",
+            headers={"Authorization": "Bearer key-alice"},
+        )
+        assert resp.status_code == 400
+        assert "Invalid limit" in resp.json()["detail"]
+
+        resp = multi_user_client.get(
+            "/api/me/runs?limit=5&offset=-1",
+            headers={"Authorization": "Bearer key-alice"},
+        )
+        assert resp.status_code == 400
+        assert "Invalid offset" in resp.json()["detail"]
+
     def test_non_ops_user_cannot_access_ops_summary(self, multi_user_client):
         resp = multi_user_client.get(
             "/api/ops/summary",


### PR DESCRIPTION
## Summary
- validate /api/me/runs and /api/runs pagination inputs before they reach the repository layer
- preserve the existing limit <= 200 cap while rejecting non-positive limits and negative offsets
- add focused regression coverage and sync the local session/tracker docs

## Validation
- python -m pytest -q tests/test_persistence.py tests/test_users.py
- python -m ruff check src/exa_demo/api.py src/exa_demo/api_auth.py tests/test_persistence.py tests/test_users.py