### PR TITLE
fix: persist backend artifact locations

### DIFF
--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -2,7 +2,7 @@
 
 _Generated file. Regenerate with `python scripts/generate_heartbeat.py`._
 
-_Generated: 2026-04-12T01:58:27.133516+00:00_
+_Generated: 2026-04-12T02:08:08.666053+00:00_
 
 ## Current status
 - Purpose: Exa-powered insurance intelligence toolkit for CAT-loss, claims, expert, contractor, and market/regulatory research workflows.
@@ -59,24 +59,23 @@ _Generated: 2026-04-12T01:58:27.133516+00:00_
 - Scope beyond this scaffold into auth redesign, persistence implementation, async jobs, deployment, infra, or broader docs refactors.
 
 ## Last session
-- Date: 2026-04-11c
-- Objective: Harden one more request-boundary gap inside `#22` by validating run-list pagination before repository queries execute.
+- Date: 2026-04-11d
+- Objective: Start `#23` with a narrow persistence fix so stored artifact locations reflect the actual backend location after upload.
 - Changes made:
-  - Inspected `/api/me/runs` and `/api/runs` in `src/exa_demo/api.py` and confirmed both routes only capped large limits while still accepting negative pagination values.
-  - Confirmed `src/exa_demo/persistence.py` used the incoming pagination values directly in SQL `LIMIT` and `OFFSET` clauses across the repository adapters.
-  - Added `validate_pagination(...)` in `src/exa_demo/api_auth.py` to reject non-positive limits and negative offsets while preserving the existing 200-item cap.
-  - Applied the shared pagination validator to both run-list routes in `src/exa_demo/api.py`.
-  - Added focused regression coverage in `tests/test_persistence.py` and `tests/test_users.py` for invalid ops/global and per-user pagination inputs.
-  - Synced the security doc and tracker/session pointers for this slice.
+  - Inspected `persist_workflow_run(...)` in `src/exa_demo/persistence.py` and `_run_job(...)` in `src/exa_demo/jobs.py` and confirmed both stored local experiment paths after artifact upload.
+  - Added `run_location(run_id)` to the artifact-store contract and implemented it for both `LocalArtifactStore` and `S3ArtifactStore`.
+  - Updated the sync persistence helper and async job runner to persist the artifact-store location instead of the source directory when uploads succeed.
+  - Added focused coverage for local-store run locations, S3-store run locations, persisted S3 artifact locations, and async job artifact-location persistence.
+  - Synced the local tracker/session pointers for this first `#23` slice.
 - Validation:
-  - Ran `python -m pytest -q tests/test_persistence.py tests/test_users.py` and confirmed `66 passed`.
-  - Ran `python -m ruff check src/exa_demo/api.py src/exa_demo/api_auth.py tests/test_persistence.py tests/test_users.py` and confirmed all checks passed.
+  - Ran `python -m pytest -q tests/test_persistence.py tests/test_jobs.py` and confirmed `54 passed`.
+  - Ran `python -m ruff check src/exa_demo/persistence.py src/exa_demo/jobs.py tests/test_persistence.py tests/test_jobs.py` and confirmed all checks passed.
 - Open issues:
-  - This slice intentionally preserved the existing oversized-limit cap semantics instead of redesigning pagination or response metadata.
-  - The repo still has no concrete shipped contract for saved-query label bounds, so that remains a weak candidate for more `#22` work.
+  - This slice did not add live S3 or Postgres integration coverage; it only tightened the backend-location contract around the existing abstractions.
+  - The repo still needs more thin `#23` slices before cloud-backed persistence is operationally well pinned.
 - Decisions proposed:
-  - Continue to centralize request-boundary helpers in `api_auth.py` when they apply across multiple FastAPI routes.
-  - Treat future `#22` slices as complete only when they map to one inspected route or helper plus focused regression coverage.
+  - Treat stored artifact locations as canonical store references so later pilot surfaces can dereference artifacts without guessing whether a run used local or S3-backed storage.
+  - Keep `#23` additive and test-first by tightening one persistence contract at a time instead of attempting a broad rollout.
 
 ## Next thin slice
-- Reassess whether another evidence-backed `#22` gap still exists; if not, move to the first thin `#23` persistence baseline slice.
+- Add one more thin `#23` slice around persistence factory success paths or a small Postgres/S3 seam that can be verified without live infrastructure.

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -45,7 +45,7 @@ Update it whenever issues are created, closed, re-scoped, or moved between miles
 | `#20 Thin FastAPI wrapper over existing workflows` | Task | `Phase 5 - Pilot` | `type:task`, `area:api`, `priority:p0`, `status:done` | Done | `#19` | Phase 5 Level 1 | TBD | `docs/sessions/2026-03-22-api-wrapper.md` |
 | `#21 Frontend app shell (Next.js + Tailwind + shadcn/ui)` | Task | `Phase 5 - Pilot` | `type:task`, `area:frontend`, `priority:p0`, `status:done` | Done | `#19, #20` | Phase 5 Level 1 | TBD | `docs/sessions/2026-03-22-frontend-shell.md` |
 | `#22 Pilot auth + request/budget boundary controls` | Task | `Phase 5 - Pilot` | `type:task`, `area:auth`, `priority:p0`, `status:next` | Next | `#19, #20` | Phase 5 Level 1 | TBD | `docs/sessions/2026-04-11-issue-22-run-pagination-bounds.md` |
-| `#23 Persistence/state baseline (S3 artifacts + Postgres usage)` | Task | `Phase 5 - Pilot` | `type:task`, `area:infra`, `priority:p1`, `status:next` | Next | `#19, #20` | Phase 5 Level 1 | TBD | `docs/sessions/2026-03-22-pilot-alignment.md` |
+| `#23 Persistence/state baseline (S3 artifacts + Postgres usage)` | Task | `Phase 5 - Pilot` | `type:task`, `area:infra`, `priority:p1`, `status:next` | Next | `#19, #20` | Phase 5 Level 1 | TBD | `docs/sessions/2026-04-11-issue-23-artifact-location-origin.md` |
 
 ### Next Coding Slices (Sequenced)
 

--- a/docs/sessions/2026-04-11-issue-23-artifact-location-origin.md
+++ b/docs/sessions/2026-04-11-issue-23-artifact-location-origin.md
@@ -1,0 +1,49 @@
+# Session: Issue 23 artifact location origin
+
+- Date: 2026-04-11
+- Participants: Codex, user
+- Related roadmap items: `#23`, `#17`
+- Related ADRs: none
+
+## Context
+
+Start `#23` with the thinnest concrete persistence-baseline fix by inspecting how uploaded artifact locations are recorded and making that persisted location match the actual storage backend.
+
+## Repo Facts Observed
+
+- `src/exa_demo/persistence.py` already shipped additive persistence factories for local-vs-S3 artifact storage and local-vs-Postgres run metadata.
+- `persist_workflow_run(...)` uploaded artifacts through the configured `ArtifactStore` but still persisted `artifact_location` as the local experiment directory path.
+- `src/exa_demo/jobs.py` repeated the same local-path assignment after background-job artifact uploads.
+- The existing tests covered local artifact upload counts and factory guards, but they did not pin the canonical persisted artifact location for either managed local storage or S3-backed storage.
+
+## Decisions Made
+
+- Treat `artifact_location` as the canonical storage-backend location for a run, not the transient source directory that happened to be uploaded.
+- Add a shared `run_location(run_id)` capability to artifact stores so sync and async persistence paths can use the same backend-aware location contract.
+- Keep this slice bounded to persisted location semantics and tests; do not widen into broader Postgres/S3 rollout or deployment work.
+
+## Issues Opened or Updated
+
+- `#23 Persistence/state baseline (S3 artifacts + Postgres usage)` - advanced with backend-aware artifact location persistence and updated local tracker/session pointers.
+- `#17 Maintain roadmap, issue tracker, ADRs, and session notes` - updated indirectly through the required session/memory/heartbeat sync.
+
+## Docs Touched
+
+- `docs/issue-tracker.md`
+- `docs/sessions/2026-04-11-issue-23-artifact-location-origin.md`
+
+## Tests and Checks Run
+
+- `python -m pytest -q tests/test_persistence.py tests/test_jobs.py` -> passed (`54 passed`)
+- `python -m ruff check src/exa_demo/persistence.py src/exa_demo/jobs.py tests/test_persistence.py tests/test_jobs.py` -> passed
+
+## Outcome
+
+- Persisted artifact locations now reflect the configured artifact-store backend instead of the local experiment source directory.
+- The sync persistence helper and async job runner now share the same canonical run-location contract.
+- Added focused local-store, S3-store, and async-job regression coverage for the persisted artifact location.
+
+## Next-Session Handoff
+
+- Continue `#23` with another thin persistence-baseline slice, likely factory success-path coverage or one small Postgres/S3 integration seam that can be tested without live infrastructure.
+- Avoid broad rollout, deployment, or migration work until the remaining persistence contracts are pinned more tightly.

--- a/heartbeat.json
+++ b/heartbeat.json
@@ -1,6 +1,6 @@
 {
   "repo": "exai-insurance-intel",
-  "generated_at": "2026-04-12T01:58:27.133516+00:00",
+  "generated_at": "2026-04-12T02:08:08.666053+00:00",
   "purpose": "Exa-powered insurance intelligence toolkit for CAT-loss, claims, expert, contractor, and market/regulatory research workflows.",
   "strategic_role": "Workflow engine plus controlled pilot web-product base for internal insurance-intelligence validation.",
   "current_milestone": "Phase 5 Level 1 is partially complete: the thin FastAPI wrapper and frontend shell are shipped, while pilot auth/request controls and persistence baseline remain the next bounded slices.",
@@ -51,33 +51,32 @@
   ],
   "update_policy": "`MEMORY.md` stays curated and human-reviewed. `memory/YYYY-MM-DD.md` stays append-only. `HEARTBEAT.md` and `heartbeat.json` are reproducible generated outputs and are never the durable source of truth.",
   "last_session": {
-    "date": "2026-04-11c",
-    "objective": "Harden one more request-boundary gap inside `#22` by validating run-list pagination before repository queries execute.",
+    "date": "2026-04-11d",
+    "objective": "Start `#23` with a narrow persistence fix so stored artifact locations reflect the actual backend location after upload.",
     "changes_made": [
-      "Inspected `/api/me/runs` and `/api/runs` in `src/exa_demo/api.py` and confirmed both routes only capped large limits while still accepting negative pagination values.",
-      "Confirmed `src/exa_demo/persistence.py` used the incoming pagination values directly in SQL `LIMIT` and `OFFSET` clauses across the repository adapters.",
-      "Added `validate_pagination(...)` in `src/exa_demo/api_auth.py` to reject non-positive limits and negative offsets while preserving the existing 200-item cap.",
-      "Applied the shared pagination validator to both run-list routes in `src/exa_demo/api.py`.",
-      "Added focused regression coverage in `tests/test_persistence.py` and `tests/test_users.py` for invalid ops/global and per-user pagination inputs.",
-      "Synced the security doc and tracker/session pointers for this slice."
+      "Inspected `persist_workflow_run(...)` in `src/exa_demo/persistence.py` and `_run_job(...)` in `src/exa_demo/jobs.py` and confirmed both stored local experiment paths after artifact upload.",
+      "Added `run_location(run_id)` to the artifact-store contract and implemented it for both `LocalArtifactStore` and `S3ArtifactStore`.",
+      "Updated the sync persistence helper and async job runner to persist the artifact-store location instead of the source directory when uploads succeed.",
+      "Added focused coverage for local-store run locations, S3-store run locations, persisted S3 artifact locations, and async job artifact-location persistence.",
+      "Synced the local tracker/session pointers for this first `#23` slice."
     ],
     "validation_run": [
-      "Ran `python -m pytest -q tests/test_persistence.py tests/test_users.py` and confirmed `66 passed`.",
-      "Ran `python -m ruff check src/exa_demo/api.py src/exa_demo/api_auth.py tests/test_persistence.py tests/test_users.py` and confirmed all checks passed."
+      "Ran `python -m pytest -q tests/test_persistence.py tests/test_jobs.py` and confirmed `54 passed`.",
+      "Ran `python -m ruff check src/exa_demo/persistence.py src/exa_demo/jobs.py tests/test_persistence.py tests/test_jobs.py` and confirmed all checks passed."
     ],
     "open_issues": [
-      "This slice intentionally preserved the existing oversized-limit cap semantics instead of redesigning pagination or response metadata.",
-      "The repo still has no concrete shipped contract for saved-query label bounds, so that remains a weak candidate for more `#22` work."
+      "This slice did not add live S3 or Postgres integration coverage; it only tightened the backend-location contract around the existing abstractions.",
+      "The repo still needs more thin `#23` slices before cloud-backed persistence is operationally well pinned."
     ],
     "decisions_proposed": [
-      "Continue to centralize request-boundary helpers in `api_auth.py` when they apply across multiple FastAPI routes.",
-      "Treat future `#22` slices as complete only when they map to one inspected route or helper plus focused regression coverage."
+      "Treat stored artifact locations as canonical store references so later pilot surfaces can dereference artifacts without guessing whether a run used local or S3-backed storage.",
+      "Keep `#23` additive and test-first by tightening one persistence contract at a time instead of attempting a broad rollout."
     ],
     "next_thin_slice": [
-      "Reassess whether another evidence-backed `#22` gap still exists; if not, move to the first thin `#23` persistence baseline slice."
+      "Add one more thin `#23` slice around persistence factory success paths or a small Postgres/S3 seam that can be verified without live infrastructure."
     ]
   },
   "next_thin_slice": [
-    "Reassess whether another evidence-backed `#22` gap still exists; if not, move to the first thin `#23` persistence baseline slice."
+    "Add one more thin `#23` slice around persistence factory success paths or a small Postgres/S3 seam that can be verified without live infrastructure."
   ]
 }

--- a/memory/2026-04-11d.md
+++ b/memory/2026-04-11d.md
@@ -1,0 +1,26 @@
+# Session Memory
+
+## Objective
+Start `#23` with a narrow persistence fix so stored artifact locations reflect the actual backend location after upload.
+
+## Changes made
+- Inspected `persist_workflow_run(...)` in `src/exa_demo/persistence.py` and `_run_job(...)` in `src/exa_demo/jobs.py` and confirmed both stored local experiment paths after artifact upload.
+- Added `run_location(run_id)` to the artifact-store contract and implemented it for both `LocalArtifactStore` and `S3ArtifactStore`.
+- Updated the sync persistence helper and async job runner to persist the artifact-store location instead of the source directory when uploads succeed.
+- Added focused coverage for local-store run locations, S3-store run locations, persisted S3 artifact locations, and async job artifact-location persistence.
+- Synced the local tracker/session pointers for this first `#23` slice.
+
+## Validation run
+- Ran `python -m pytest -q tests/test_persistence.py tests/test_jobs.py` and confirmed `54 passed`.
+- Ran `python -m ruff check src/exa_demo/persistence.py src/exa_demo/jobs.py tests/test_persistence.py tests/test_jobs.py` and confirmed all checks passed.
+
+## Open issues
+- This slice did not add live S3 or Postgres integration coverage; it only tightened the backend-location contract around the existing abstractions.
+- The repo still needs more thin `#23` slices before cloud-backed persistence is operationally well pinned.
+
+## Decisions proposed
+- Treat stored artifact locations as canonical store references so later pilot surfaces can dereference artifacts without guessing whether a run used local or S3-backed storage.
+- Keep `#23` additive and test-first by tightening one persistence contract at a time instead of attempting a broad rollout.
+
+## Next thin slice
+- Add one more thin `#23` slice around persistence factory success paths or a small Postgres/S3 seam that can be verified without live infrastructure.

--- a/src/exa_demo/jobs.py
+++ b/src/exa_demo/jobs.py
@@ -130,7 +130,10 @@ def _run_job(
                         record.run_id, art_dir
                     )
                     record.artifact_count = len(locations)
-                    record.artifact_location = str(art_dir)
+                    if locations:
+                        record.artifact_location = artifact_store.run_location(
+                            record.run_id
+                        )
                 except Exception:
                     logger.exception(
                         "Failed to upload artifacts for job %s", record_id

--- a/src/exa_demo/persistence.py
+++ b/src/exa_demo/persistence.py
@@ -120,6 +120,10 @@ class ArtifactStore(Protocol):
         """List stored artifact locations for a run."""
         ...
 
+    def run_location(self, run_id: str) -> str:
+        """Return the canonical store location for a run's artifacts."""
+        ...
+
 
 class LocalArtifactStore:
     """Artifact store backed by the local filesystem.
@@ -159,6 +163,9 @@ class LocalArtifactStore:
         if not run_dir.is_dir():
             return []
         return [str(p) for p in sorted(run_dir.iterdir()) if p.is_file()]
+
+    def run_location(self, run_id: str) -> str:
+        return str(self.base_dir / run_id)
 
 
 class S3ArtifactStore:
@@ -208,6 +215,9 @@ class S3ArtifactStore:
             f"s3://{self.bucket}/{obj['Key']}"
             for obj in resp.get("Contents", [])
         ]
+
+    def run_location(self, run_id: str) -> str:
+        return f"s3://{self.bucket}/{self.prefix}{run_id}/"
 
 
 # ---------------------------------------------------------------------------
@@ -980,7 +990,8 @@ def persist_workflow_run(
             try:
                 locations = artifact_store.upload_directory(run_id, art_dir)
                 record.artifact_count = len(locations)
-                record.artifact_location = str(art_dir)
+                if locations:
+                    record.artifact_location = artifact_store.run_location(run_id)
             except Exception:
                 logger.exception("Failed to upload artifacts for run %s", run_id)
 

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -178,6 +178,29 @@ class TestSubmitJob:
         assert "running" in observed_statuses
         assert "completed" in observed_statuses
 
+    def test_job_uploads_artifacts_to_store_location(self, repo, store, tmp_path):
+        art_dir = tmp_path / "artifacts" / "run-artifacts"
+        art_dir.mkdir(parents=True)
+        (art_dir / "config.json").write_text("{}")
+        (art_dir / "summary.json").write_text("{}")
+
+        record = jobs_module.submit_job(
+            run_repo=repo,
+            artifact_store=store,
+            workflow="research",
+            mode="smoke",
+            request_id=None,
+            query_preview="test",
+            run_fn=lambda: {"run_id": "run-artifacts", "summary": {}},
+            artifact_dir=str(tmp_path / "artifacts"),
+        )
+        _wait_for_job(repo, record.id)
+
+        completed = repo.get(record.id)
+        assert completed is not None
+        assert completed.artifact_count == 2
+        assert completed.artifact_location == str(tmp_path / "store" / "run-artifacts")
+
 
 # ---------------------------------------------------------------------------
 # API endpoint tests

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -99,6 +99,39 @@ class TestLocalArtifactStore:
         store = persist_module.LocalArtifactStore(base_dir=tmp_path / "store")
         assert store.list_artifacts("nonexistent") == []
 
+    def test_run_location_uses_store_path(self, tmp_path):
+        store = persist_module.LocalArtifactStore(base_dir=tmp_path / "store")
+        assert store.run_location("run-1") == str(tmp_path / "store" / "run-1")
+
+
+class _FakeS3Client:
+    def __init__(self):
+        self.uploads = []
+
+    def upload_file(self, local_path, bucket, key):
+        self.uploads.append((local_path, bucket, key))
+
+    def list_objects_v2(self, Bucket, Prefix):  # noqa: N803
+        contents = [
+            {"Key": key}
+            for _, bucket, key in self.uploads
+            if bucket == Bucket and key.startswith(Prefix)
+        ]
+        return {"Contents": contents}
+
+
+class TestS3ArtifactStore:
+    def test_run_location_uses_s3_prefix(self):
+        store = persist_module.S3ArtifactStore(
+            bucket="pilot-artifacts",
+            prefix="runs",
+        )
+        store._client = _FakeS3Client()
+        assert (
+            store.run_location("run-1")
+            == "s3://pilot-artifacts/runs/run-1/"
+        )
+
 
 # ---------------------------------------------------------------------------
 # LocalRunRepository
@@ -243,6 +276,34 @@ class TestPersistWorkflowRun:
             artifact_dir=str(tmp_path / "experiments"),
         )
         assert record.artifact_count == 2
+        assert record.artifact_location == str(tmp_path / "store" / "run-42")
+
+    def test_persist_uploads_artifacts_to_s3_location(self, tmp_path):
+        repo = persist_module.LocalRunRepository(
+            db_path=tmp_path / "runs.sqlite"
+        )
+        store = persist_module.S3ArtifactStore(
+            bucket="pilot-artifacts",
+            prefix="runs",
+        )
+        store._client = _FakeS3Client()
+        art_dir = tmp_path / "experiments" / "run-42"
+        art_dir.mkdir(parents=True)
+        (art_dir / "config.json").write_text("{}")
+        (art_dir / "summary.json").write_text("{}")
+
+        record = persist_module.persist_workflow_run(
+            run_repo=repo,
+            artifact_store=store,
+            workflow="search",
+            mode="smoke",
+            request_id=None,
+            payload={"run_id": "run-42", "summary": {}},
+            artifact_dir=str(tmp_path / "experiments"),
+        )
+
+        assert record.artifact_count == 2
+        assert record.artifact_location == "s3://pilot-artifacts/runs/run-42/"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- make persisted rtifact_location reflect the configured artifact-store backend instead of the local experiment source directory
- add a shared un_location(run_id) contract for local and S3 artifact stores
- apply the same backend-aware location handling to both sync persistence and async jobs, with focused regression coverage

## Validation
- python -m pytest -q tests/test_persistence.py tests/test_jobs.py
- python -m ruff check src/exa_demo/persistence.py src/exa_demo/jobs.py tests/test_persistence.py tests/test_jobs.py