### PR TITLE
docs: sync phase 5 tracker state

### DIFF
--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -2,12 +2,12 @@
 
 _Generated file. Regenerate with `python scripts/generate_heartbeat.py`._
 
-_Generated: 2026-04-12T02:08:08.666053+00:00_
+_Generated: 2026-04-12T02:14:21.887065+00:00_
 
 ## Current status
 - Purpose: Exa-powered insurance intelligence toolkit for CAT-loss, claims, expert, contractor, and market/regulatory research workflows.
 - Strategic role: Workflow engine plus controlled pilot web-product base for internal insurance-intelligence validation.
-- Current milestone: Phase 5 Level 1 is partially complete: the thin FastAPI wrapper and frontend shell are shipped, while pilot auth/request controls and persistence baseline remain the next bounded slices.
+- Current milestone: Phase 5 Level 1 is partially complete: the thin FastAPI wrapper, frontend shell, and pilot auth/request-boundary hardening are shipped, and the persistence baseline is now the active next bounded slice.
 
 ## Operating posture
 - Active Python workflow repo with package code in `src/exa_demo/`, a thin FastAPI app in the same package, and a Next.js frontend in `frontend/`. SQLite cache, budget controls, benchmark fixtures, exported artifacts, and smoke/live execution modes are already in place. Manual live validation is script-backed, but the inspected docs only verify smoke validation runs so far.
@@ -20,8 +20,8 @@ _Generated: 2026-04-12T02:08:08.666053+00:00_
 - Durable memory must stay curated and human-reviewed; heartbeat artifacts are generated sidecars, not the source of truth.
 
 ## Top blockers
-- Phase 5 Level 1 is not complete because auth, request-boundary controls, rate limiting, and request logging are still the next slice in `docs/issue-tracker.md`.
-- Pilot persistence baseline is still missing; local SQLite is present, but the planned S3/Postgres pilot path is not yet implemented.
+- Phase 5 Level 1 is not complete because the persistence baseline is still missing; local SQLite is present, but the planned S3/Postgres pilot path is not yet implemented.
+- GitHub issue numbering has drifted from the local Phase 5 roadmap IDs, so the tracker still has `TBD` GitHub URLs for those items until dedicated issues are created.
 - Docs freshness is mixed because `docs/pilot-architecture-decision.md` and `docs/sessions/2026-03-22-pilot-alignment.md` still describe a pre-slice state with no frontend/API layer, while README and later slice notes show both shipped.
 
 ## Docs + setup
@@ -59,23 +59,22 @@ _Generated: 2026-04-12T02:08:08.666053+00:00_
 - Scope beyond this scaffold into auth redesign, persistence implementation, async jobs, deployment, infra, or broader docs refactors.
 
 ## Last session
-- Date: 2026-04-11d
-- Objective: Start `#23` with a narrow persistence fix so stored artifact locations reflect the actual backend location after upload.
+- Date: 2026-04-11e
+- Objective: Take a simple end-of-session docs slice by syncing the local Phase 5 tracker and durable memory to the merged work.
 - Changes made:
-  - Inspected `persist_workflow_run(...)` in `src/exa_demo/persistence.py` and `_run_job(...)` in `src/exa_demo/jobs.py` and confirmed both stored local experiment paths after artifact upload.
-  - Added `run_location(run_id)` to the artifact-store contract and implemented it for both `LocalArtifactStore` and `S3ArtifactStore`.
-  - Updated the sync persistence helper and async job runner to persist the artifact-store location instead of the source directory when uploads succeed.
-  - Added focused coverage for local-store run locations, S3-store run locations, persisted S3 artifact locations, and async job artifact-location persistence.
-  - Synced the local tracker/session pointers for this first `#23` slice.
+  - Inspected the local tracker, roadmap, heartbeat, and memory snapshot after the merged `#22` and first `#23` slices.
+  - Marked the local Phase 5 `#22` tracker item as done and kept `#23` as the active next slice.
+  - Updated the roadmap and `MEMORY.md` so they reflect that auth/request-boundary hardening is shipped and persistence is now the primary Phase 5 Level 1 blocker.
+  - Documented the Phase 5 numbering drift: local tracker IDs `#19`-`#23` are roadmap/task IDs, while GitHub numbers `22` and `23` are already occupied by older merged PRs.
+  - Added the session note and synced the tracker pointer for `#17`.
 - Validation:
-  - Ran `python -m pytest -q tests/test_persistence.py tests/test_jobs.py` and confirmed `54 passed`.
-  - Ran `python -m ruff check src/exa_demo/persistence.py src/exa_demo/jobs.py tests/test_persistence.py tests/test_jobs.py` and confirmed all checks passed.
+  - No code or test changes; docs-only sync.
 - Open issues:
-  - This slice did not add live S3 or Postgres integration coverage; it only tightened the backend-location contract around the existing abstractions.
-  - The repo still needs more thin `#23` slices before cloud-backed persistence is operationally well pinned.
+  - Dedicated GitHub issues still need to be created for the local Phase 5 tracker items if the repo wants live issue links instead of `TBD`.
+  - `docs/pilot-architecture-decision.md` and the earlier pilot-alignment note still lag the shipped API/frontend reality.
 - Decisions proposed:
-  - Treat stored artifact locations as canonical store references so later pilot surfaces can dereference artifacts without guessing whether a run used local or S3-backed storage.
-  - Keep `#23` additive and test-first by tightening one persistence contract at a time instead of attempting a broad rollout.
+  - Treat the local Phase 5 tracker IDs as internal roadmap IDs until dedicated GitHub issues are created, instead of linking them to unrelated GitHub numbers.
+  - Keep the next coding work on `#23` persistence slices rather than reopening the completed `#22` boundary track.
 
 ## Next thin slice
-- Add one more thin `#23` slice around persistence factory success paths or a small Postgres/S3 seam that can be verified without live infrastructure.
+- Continue `#23` with another small persistence-baseline seam, or end the session here if you want to wind down cleanly.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -32,7 +32,7 @@ Exa-powered insurance intelligence toolkit for CAT-loss, claims, expert, contrac
 Workflow engine plus controlled pilot web-product base for internal insurance-intelligence validation.
 
 ## Current milestone
-Phase 5 Level 1 is partially complete: the thin FastAPI wrapper and frontend shell are shipped, while pilot auth/request controls and persistence baseline remain the next bounded slices.
+Phase 5 Level 1 is partially complete: the thin FastAPI wrapper, frontend shell, and pilot auth/request-boundary hardening are shipped, and the persistence baseline is now the active next bounded slice.
 
 ## Durable decisions
 - Markdown docs under `docs/` remain the canonical backlog, architecture, ADR, and session-history surface for this repo.
@@ -45,8 +45,8 @@ Phase 5 Level 1 is partially complete: the thin FastAPI wrapper and frontend she
 Active Python workflow repo with package code in `src/exa_demo/`, a thin FastAPI app in the same package, and a Next.js frontend in `frontend/`. SQLite cache, budget controls, benchmark fixtures, exported artifacts, and smoke/live execution modes are already in place. Manual live validation is script-backed, but the inspected docs only verify smoke validation runs so far.
 
 ## Top blockers
-- Phase 5 Level 1 is not complete because auth, request-boundary controls, rate limiting, and request logging are still the next slice in `docs/issue-tracker.md`.
-- Pilot persistence baseline is still missing; local SQLite is present, but the planned S3/Postgres pilot path is not yet implemented.
+- Phase 5 Level 1 is not complete because the persistence baseline is still missing; local SQLite is present, but the planned S3/Postgres pilot path is not yet implemented.
+- GitHub issue numbering has drifted from the local Phase 5 roadmap IDs, so the tracker still has `TBD` GitHub URLs for those items until dedicated issues are created.
 - Docs freshness is mixed because `docs/pilot-architecture-decision.md` and `docs/sessions/2026-03-22-pilot-alignment.md` still describe a pre-slice state with no frontend/API layer, while README and later slice notes show both shipped.
 
 ## Docs freshness

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -34,7 +34,7 @@ Update it whenever issues are created, closed, re-scoped, or moved between miles
 | `#14 Add export/report outputs and demo-gallery documentation` | Task | `Phase 3 - Domain/Productization` | `type:task`, `area:docs`, `priority:p1`, `status:ready` | Closed | `#12, #7, #8, #13` | Phase 3 - Domain Coverage and Productization | `https://github.com/itprodirect/exai-insurance-intel/issues/14` | `docs/sessions/2026-04-11-issue-14-report-export.md` |
 | `#15 Epic: Documentation, governance, and repo operations` | Epic | `Phase 3 - Domain/Productization` | `type:epic`, `area:ops`, `priority:p0`, `status:ready` | Open | None | Phase 4 - Documentation, Governance, and Repo Operations | `https://github.com/itprodirect/exai-insurance-intel/issues/15` | `docs/sessions/2026-03-10-roadmap-baseline.md` |
 | `#16 Extend CI/security hardening and document integration follow-ons` | Task | `Phase 3 - Domain/Productization` | `type:task`, `area:ops`, `priority:p1`, `status:ready` | In progress | `#15, #14` | Phase 3 - Domain Coverage and Productization | `https://github.com/itprodirect/exai-insurance-intel/issues/16` | `docs/sessions/2026-03-21-payload-boundary-cleanup.md` |
-| `#17 Maintain roadmap, issue tracker, ADRs, and session notes` | Task | `Phase 3 - Domain/Productization` | `type:task`, `area:docs`, `priority:p0`, `status:ready` | In progress | `#15` | Phase 4 - Documentation, Governance, and Repo Operations | `https://github.com/itprodirect/exai-insurance-intel/issues/17` | `docs/sessions/2026-04-11-issue-22-rate-limit-scope.md` |
+| `#17 Maintain roadmap, issue tracker, ADRs, and session notes` | Task | `Phase 3 - Domain/Productization` | `type:task`, `area:docs`, `priority:p0`, `status:ready` | In progress | `#15` | Phase 4 - Documentation, Governance, and Repo Operations | `https://github.com/itprodirect/exai-insurance-intel/issues/17` | `docs/sessions/2026-04-11-issue-17-phase5-tracker-sync.md` |
 | `#18 Upgrade README with feature matrix, architecture diagram, and roadmap links` | Task | `Phase 3 - Domain/Productization` | `type:task`, `area:docs`, `priority:p1`, `status:ready` | Closed | `#15` | Phase 4 - Documentation, Governance, and Repo Operations | `https://github.com/itprodirect/exai-insurance-intel/issues/18` | `docs/sessions/2026-03-18-phase2-parallel-slices.md` |
 
 ## Phase 5 - Pilot Web Product
@@ -44,7 +44,7 @@ Update it whenever issues are created, closed, re-scoped, or moved between miles
 | `#19 Epic: Pilot web product layer` | Epic | `Phase 5 - Pilot` | `type:epic`, `area:pilot`, `priority:p0`, `status:ready` | Open | Phases 1-4 | Phase 5 - Pilot Web Product | TBD | `docs/sessions/2026-03-22-pilot-alignment.md` |
 | `#20 Thin FastAPI wrapper over existing workflows` | Task | `Phase 5 - Pilot` | `type:task`, `area:api`, `priority:p0`, `status:done` | Done | `#19` | Phase 5 Level 1 | TBD | `docs/sessions/2026-03-22-api-wrapper.md` |
 | `#21 Frontend app shell (Next.js + Tailwind + shadcn/ui)` | Task | `Phase 5 - Pilot` | `type:task`, `area:frontend`, `priority:p0`, `status:done` | Done | `#19, #20` | Phase 5 Level 1 | TBD | `docs/sessions/2026-03-22-frontend-shell.md` |
-| `#22 Pilot auth + request/budget boundary controls` | Task | `Phase 5 - Pilot` | `type:task`, `area:auth`, `priority:p0`, `status:next` | Next | `#19, #20` | Phase 5 Level 1 | TBD | `docs/sessions/2026-04-11-issue-22-run-pagination-bounds.md` |
+| `#22 Pilot auth + request/budget boundary controls` | Task | `Phase 5 - Pilot` | `type:task`, `area:auth`, `priority:p0`, `status:done` | Done | `#19, #20` | Phase 5 Level 1 | TBD | `docs/sessions/2026-04-11-issue-22-run-pagination-bounds.md` |
 | `#23 Persistence/state baseline (S3 artifacts + Postgres usage)` | Task | `Phase 5 - Pilot` | `type:task`, `area:infra`, `priority:p1`, `status:next` | Next | `#19, #20` | Phase 5 Level 1 | TBD | `docs/sessions/2026-04-11-issue-23-artifact-location-origin.md` |
 
 ### Next Coding Slices (Sequenced)
@@ -53,14 +53,19 @@ These are the immediate next implementation tasks, in recommended execution orde
 
 1. ~~**Slice 1: Thin API wrapper** (`#20`)~~ — Done. FastAPI app at `src/exa_demo/api.py` with 5 POST endpoints + health. 9 smoke-mode tests.
 2. ~~**Slice 2: Frontend app shell** (`#21`)~~ — Done. Next.js app in `frontend/` with search, answer, research panels. Server-side proxy to backend.
-3. **Slice 3: Pilot auth + boundary controls** (`#22`) — Internal-only auth (API key or simple token), request validation, rate limiting, per-session budget caps, request logging middleware.
-4. **Slice 4: Persistence baseline** (`#23`) — S3 artifact storage for run outputs, Postgres for usage/state tracking, migration from local-only SQLite for pilot environments.
+3. ~~**Slice 3: Pilot auth + boundary controls** (`#22`)~~ — Done. Owner-or-ops record access, multi-user rate-limit isolation, saved-query input bounds, and run-pagination bounds are shipped.
+4. **Slice 4: Persistence baseline** (`#23`) — Current next slice. S3 artifact storage for run outputs, Postgres for usage/state tracking, migration from local-only SQLite for pilot environments.
 
 Each slice should be one focused agent session. See [agent-execution-defaults.md](./agent-execution-defaults.md) for session rules.
 
 ## Usage Rules
 
-- Every active roadmap item outside Phase 0 must map to exactly one GitHub issue.
+- Every active roadmap item outside Phase 0 should map to exactly one GitHub issue. If the mapping does not exist yet, leave the GitHub URL as `TBD` and document the drift explicitly.
 - Close the roadmap item and issue together, or document why they diverged.
 - Update the `Last-updated session log` field whenever the issue scope, status, or acceptance criteria changes.
 - Record durable process changes in `docs/adr/`.
+
+## Phase 5 Numbering Note
+
+- The Phase 5 local tracker IDs `#19`-`#23` are roadmap/task IDs used in repo docs.
+- GitHub issue numbers `22` and `23` are already occupied by older merged PRs, so the `GitHub URL` field for the local Phase 5 `#22` and `#23` items remains `TBD` until dedicated GitHub issues are created.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -135,8 +135,8 @@ Goal: a working web UI that internal users can use to run existing workflows thr
 | --- | --- | --- | --- | --- | --- | --- |
 | Thin API wrapper | Expose existing workflows as FastAPI endpoints | Decouples frontend from Python CLI; enables web product path | `Done` | Phase 1-4 baseline | FastAPI app serves search, answer, research, find-similar, structured-search over HTTP with JSON responses | TBD |
 | Frontend app shell | Next.js + TypeScript + Tailwind + shadcn/ui scaffold with App Router | Establishes the frontend stack and deploy target | `Done` | Thin API wrapper | App shell renders, routes work, can call API endpoints | TBD |
-| Pilot auth + request boundary | Internal-only auth, request validation, rate limiting, budget guardrails, request logging | Prevents uncontrolled usage before the product is hardened | `Next` | Thin API wrapper | Only authenticated internal users can make requests; spend is bounded and logged | TBD |
-| Persistence baseline | Artifacts in S3, relational state/usage in Postgres, existing SQLite cache kept for local dev | Moves beyond local-only SQLite for pilot durability | `Next` | Thin API wrapper | Pilot runs persist artifacts to S3 and track usage in Postgres | TBD |
+| Pilot auth + request boundary | Internal-only auth, request validation, rate limiting, budget guardrails, request logging | Prevents uncontrolled usage before the product is hardened | `Done` | Thin API wrapper | Only authenticated internal users can make requests; spend is bounded and logged | TBD |
+| Persistence baseline | Artifacts in S3, relational state/usage in Postgres, existing SQLite cache kept for local dev | Moves beyond local-only SQLite for pilot durability | `Current` | Thin API wrapper | Pilot runs persist artifacts to S3 and track usage in Postgres | TBD |
 
 ### Level 2 - Limited External Beta
 
@@ -174,6 +174,5 @@ These are preserved as future exploration themes, but they are not committed bac
 - [Improvement roadmap](./exai-insurance-intel-improvements.md)
 - [docs/rebuild_review.md](./rebuild_review.md)
 - Current repository code, tests, CI, and README baseline observed on March 10, 2026
-
 
 

--- a/docs/sessions/2026-04-11-issue-17-phase5-tracker-sync.md
+++ b/docs/sessions/2026-04-11-issue-17-phase5-tracker-sync.md
@@ -1,0 +1,48 @@
+# Session: Issue 17 Phase 5 tracker sync
+
+- Date: 2026-04-11
+- Participants: Codex, user
+- Related roadmap items: `#17`, `#22`, `#23`
+- Related ADRs: none
+
+## Context
+
+Take a simple docs/governance slice near session end by syncing the local Phase 5 tracker and memory files to the work that has already been merged.
+
+## Repo Facts Observed
+
+- The local tracker still showed `#22` as the active next slice even after multiple merged auth/request-boundary hardening passes and the first merged `#23` persistence slice.
+- `MEMORY.md` still described pilot auth/request controls as a top blocker instead of the now-active persistence baseline.
+- GitHub issue numbers `22` and `23` are already occupied by older merged PRs, so the local Phase 5 tracker IDs are currently roadmap/task IDs rather than live GitHub issue numbers.
+
+## Decisions Made
+
+- Mark the local Phase 5 `#22` tracker item as done and keep `#23` as the active next slice.
+- Update the roadmap and memory snapshot so they reflect that auth/request-boundary hardening is shipped and persistence is now the primary remaining Phase 5 Level 1 blocker.
+- Document the Phase 5 numbering drift explicitly instead of inventing incorrect GitHub links.
+
+## Issues Opened or Updated
+
+- `#17 Maintain roadmap, issue tracker, ADRs, and session notes` - advanced with a narrow Phase 5 tracker and memory sync.
+- Local tracker items `#22` and `#23` - status and sequencing synced to merged work and current slice order.
+
+## Docs Touched
+
+- `docs/issue-tracker.md`
+- `docs/roadmap.md`
+- `MEMORY.md`
+- `docs/sessions/2026-04-11-issue-17-phase5-tracker-sync.md`
+
+## Tests and Checks Run
+
+- No code or test changes; docs-only sync.
+
+## Outcome
+
+- The local tracker, roadmap, and durable memory now agree that the auth/request-boundary slice is done and persistence is the active next Phase 5 slice.
+- The tracker now explicitly notes why the Phase 5 `GitHub URL` fields remain `TBD` instead of pointing at unrelated issue/PR numbers.
+
+## Next-Session Handoff
+
+- If another small docs slice is needed later, create dedicated GitHub issues for the local Phase 5 tracker items and replace the remaining `TBD` links.
+- Otherwise keep coding effort focused on thin `#23` persistence-baseline slices.

--- a/heartbeat.json
+++ b/heartbeat.json
@@ -1,9 +1,9 @@
 {
   "repo": "exai-insurance-intel",
-  "generated_at": "2026-04-12T02:08:08.666053+00:00",
+  "generated_at": "2026-04-12T02:14:21.887065+00:00",
   "purpose": "Exa-powered insurance intelligence toolkit for CAT-loss, claims, expert, contractor, and market/regulatory research workflows.",
   "strategic_role": "Workflow engine plus controlled pilot web-product base for internal insurance-intelligence validation.",
-  "current_milestone": "Phase 5 Level 1 is partially complete: the thin FastAPI wrapper and frontend shell are shipped, while pilot auth/request controls and persistence baseline remain the next bounded slices.",
+  "current_milestone": "Phase 5 Level 1 is partially complete: the thin FastAPI wrapper, frontend shell, and pilot auth/request-boundary hardening are shipped, and the persistence baseline is now the active next bounded slice.",
   "durable_decisions": [
     "Markdown docs under `docs/` remain the canonical backlog, architecture, ADR, and session-history surface for this repo.",
     "Existing CLI commands, artifact contracts, and smoke-first workflow expectations are stable and should be extended additively rather than rewritten.",
@@ -13,8 +13,8 @@
   ],
   "operating_posture": "Active Python workflow repo with package code in `src/exa_demo/`, a thin FastAPI app in the same package, and a Next.js frontend in `frontend/`. SQLite cache, budget controls, benchmark fixtures, exported artifacts, and smoke/live execution modes are already in place. Manual live validation is script-backed, but the inspected docs only verify smoke validation runs so far.",
   "top_blockers": [
-    "Phase 5 Level 1 is not complete because auth, request-boundary controls, rate limiting, and request logging are still the next slice in `docs/issue-tracker.md`.",
-    "Pilot persistence baseline is still missing; local SQLite is present, but the planned S3/Postgres pilot path is not yet implemented.",
+    "Phase 5 Level 1 is not complete because the persistence baseline is still missing; local SQLite is present, but the planned S3/Postgres pilot path is not yet implemented.",
+    "GitHub issue numbering has drifted from the local Phase 5 roadmap IDs, so the tracker still has `TBD` GitHub URLs for those items until dedicated issues are created.",
     "Docs freshness is mixed because `docs/pilot-architecture-decision.md` and `docs/sessions/2026-03-22-pilot-alignment.md` still describe a pre-slice state with no frontend/API layer, while README and later slice notes show both shipped."
   ],
   "docs_freshness": "Mixed but workable. `README.md`, `docs/roadmap.md`, `docs/issue-tracker.md`, `docs/integration-boundaries.md`, and the 2026-03-22 implementation session notes reflect the current repo direction; the pilot architecture doc's current-state section and the pilot-alignment note lag behind the shipped API/frontend reality.",
@@ -51,32 +51,31 @@
   ],
   "update_policy": "`MEMORY.md` stays curated and human-reviewed. `memory/YYYY-MM-DD.md` stays append-only. `HEARTBEAT.md` and `heartbeat.json` are reproducible generated outputs and are never the durable source of truth.",
   "last_session": {
-    "date": "2026-04-11d",
-    "objective": "Start `#23` with a narrow persistence fix so stored artifact locations reflect the actual backend location after upload.",
+    "date": "2026-04-11e",
+    "objective": "Take a simple end-of-session docs slice by syncing the local Phase 5 tracker and durable memory to the merged work.",
     "changes_made": [
-      "Inspected `persist_workflow_run(...)` in `src/exa_demo/persistence.py` and `_run_job(...)` in `src/exa_demo/jobs.py` and confirmed both stored local experiment paths after artifact upload.",
-      "Added `run_location(run_id)` to the artifact-store contract and implemented it for both `LocalArtifactStore` and `S3ArtifactStore`.",
-      "Updated the sync persistence helper and async job runner to persist the artifact-store location instead of the source directory when uploads succeed.",
-      "Added focused coverage for local-store run locations, S3-store run locations, persisted S3 artifact locations, and async job artifact-location persistence.",
-      "Synced the local tracker/session pointers for this first `#23` slice."
+      "Inspected the local tracker, roadmap, heartbeat, and memory snapshot after the merged `#22` and first `#23` slices.",
+      "Marked the local Phase 5 `#22` tracker item as done and kept `#23` as the active next slice.",
+      "Updated the roadmap and `MEMORY.md` so they reflect that auth/request-boundary hardening is shipped and persistence is now the primary Phase 5 Level 1 blocker.",
+      "Documented the Phase 5 numbering drift: local tracker IDs `#19`-`#23` are roadmap/task IDs, while GitHub numbers `22` and `23` are already occupied by older merged PRs.",
+      "Added the session note and synced the tracker pointer for `#17`."
     ],
     "validation_run": [
-      "Ran `python -m pytest -q tests/test_persistence.py tests/test_jobs.py` and confirmed `54 passed`.",
-      "Ran `python -m ruff check src/exa_demo/persistence.py src/exa_demo/jobs.py tests/test_persistence.py tests/test_jobs.py` and confirmed all checks passed."
+      "No code or test changes; docs-only sync."
     ],
     "open_issues": [
-      "This slice did not add live S3 or Postgres integration coverage; it only tightened the backend-location contract around the existing abstractions.",
-      "The repo still needs more thin `#23` slices before cloud-backed persistence is operationally well pinned."
+      "Dedicated GitHub issues still need to be created for the local Phase 5 tracker items if the repo wants live issue links instead of `TBD`.",
+      "`docs/pilot-architecture-decision.md` and the earlier pilot-alignment note still lag the shipped API/frontend reality."
     ],
     "decisions_proposed": [
-      "Treat stored artifact locations as canonical store references so later pilot surfaces can dereference artifacts without guessing whether a run used local or S3-backed storage.",
-      "Keep `#23` additive and test-first by tightening one persistence contract at a time instead of attempting a broad rollout."
+      "Treat the local Phase 5 tracker IDs as internal roadmap IDs until dedicated GitHub issues are created, instead of linking them to unrelated GitHub numbers.",
+      "Keep the next coding work on `#23` persistence slices rather than reopening the completed `#22` boundary track."
     ],
     "next_thin_slice": [
-      "Add one more thin `#23` slice around persistence factory success paths or a small Postgres/S3 seam that can be verified without live infrastructure."
+      "Continue `#23` with another small persistence-baseline seam, or end the session here if you want to wind down cleanly."
     ]
   },
   "next_thin_slice": [
-    "Add one more thin `#23` slice around persistence factory success paths or a small Postgres/S3 seam that can be verified without live infrastructure."
+    "Continue `#23` with another small persistence-baseline seam, or end the session here if you want to wind down cleanly."
   ]
 }

--- a/memory/2026-04-11e.md
+++ b/memory/2026-04-11e.md
@@ -1,0 +1,25 @@
+# Session Memory
+
+## Objective
+Take a simple end-of-session docs slice by syncing the local Phase 5 tracker and durable memory to the merged work.
+
+## Changes made
+- Inspected the local tracker, roadmap, heartbeat, and memory snapshot after the merged `#22` and first `#23` slices.
+- Marked the local Phase 5 `#22` tracker item as done and kept `#23` as the active next slice.
+- Updated the roadmap and `MEMORY.md` so they reflect that auth/request-boundary hardening is shipped and persistence is now the primary Phase 5 Level 1 blocker.
+- Documented the Phase 5 numbering drift: local tracker IDs `#19`-`#23` are roadmap/task IDs, while GitHub numbers `22` and `23` are already occupied by older merged PRs.
+- Added the session note and synced the tracker pointer for `#17`.
+
+## Validation run
+- No code or test changes; docs-only sync.
+
+## Open issues
+- Dedicated GitHub issues still need to be created for the local Phase 5 tracker items if the repo wants live issue links instead of `TBD`.
+- `docs/pilot-architecture-decision.md` and the earlier pilot-alignment note still lag the shipped API/frontend reality.
+
+## Decisions proposed
+- Treat the local Phase 5 tracker IDs as internal roadmap IDs until dedicated GitHub issues are created, instead of linking them to unrelated GitHub numbers.
+- Keep the next coding work on `#23` persistence slices rather than reopening the completed `#22` boundary track.
+
+## Next thin slice
+- Continue `#23` with another small persistence-baseline seam, or end the session here if you want to wind down cleanly.


### PR DESCRIPTION
## Summary
- mark the local Phase 5 #22 tracker item as done and keep #23 as the active next slice
- sync the roadmap and durable memory to the merged Phase 5 work
- document the local Phase 5 tracker ID vs GitHub number drift so the remaining TBD links are explicit instead of misleading

## Validation
- docs-only sync; no code or tests changed