### PR TITLE
docs: sync README, tracker, roadmap, and architecture with Phase 5 state

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ This repo is a **backend workflow engine, API, and pilot web UI** for insurance 
 - Complete CLI with 8 commands covering all Exa API endpoints
 - FastAPI server wrapping all workflows as JSON endpoints
 - Next.js frontend with search, answer, and research workflow UIs
+- Pilot auth and request-boundary controls for bearer auth, per-user scoping, and bounded usage
 - SQLite caching with budget enforcement and cost ledger
+- Additive persistence adapters for local SQLite plus pilot S3/Postgres backends
 - Evaluation taxonomy with benchmark suites (55+ insurance queries)
 - Artifact export system (JSON/JSONL/CSV/Markdown)
 - Smoke + live execution modes with CI on every push
@@ -18,8 +20,8 @@ This repo is a **backend workflow engine, API, and pilot web UI** for insurance 
 
 **What does not exist yet:**
 - Container or cloud deployment (no Docker, no Terraform)
-- Production database (SQLite cache only)
-- Authentication or multi-user support
+- Deployed cloud persistence/infrastructure baseline for S3/Postgres-backed pilot environments
+- Production-hardened external access model
 
 **Near-term direction:** Build a controlled pilot web product layer on top of the existing workflow engine. See [docs/roadmap.md](docs/roadmap.md) for phased tracks and [docs/pilot-architecture-decision.md](docs/pilot-architecture-decision.md) for architectural defaults.
 
@@ -459,7 +461,7 @@ For a from-scratch architecture critique and refactor roadmap, see `docs/rebuild
 - GitHub issue tracker mapping: [docs/issue-tracker.md](docs/issue-tracker.md)
 - ADR index: [docs/adr/README.md](docs/adr/README.md)
 - Session note template: [docs/sessions/README.md](docs/sessions/README.md)
-- Latest implementation session: [docs/sessions/2026-03-20-phase4-refactor-decomposition.md](docs/sessions/2026-03-20-phase4-refactor-decomposition.md)
+- Latest implementation session: [docs/sessions/2026-04-12-issue-17-docs-truth-sync.md](docs/sessions/2026-04-12-issue-17-docs-truth-sync.md)
 
 ## Guardrails
 
@@ -468,5 +470,4 @@ For a from-scratch architecture critique and refactor roadmap, see `docs/rebuild
 - No contact harvesting
 - Redaction stays enabled in notebook output
 - Human review required before operational use
-
 

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -34,7 +34,7 @@ Update it whenever issues are created, closed, re-scoped, or moved between miles
 | `#14 Add export/report outputs and demo-gallery documentation` | Task | `Phase 3 - Domain/Productization` | `type:task`, `area:docs`, `priority:p1`, `status:ready` | Closed | `#12, #7, #8, #13` | Phase 3 - Domain Coverage and Productization | `https://github.com/itprodirect/exai-insurance-intel/issues/14` | `docs/sessions/2026-04-11-issue-14-report-export.md` |
 | `#15 Epic: Documentation, governance, and repo operations` | Epic | `Phase 3 - Domain/Productization` | `type:epic`, `area:ops`, `priority:p0`, `status:ready` | Open | None | Phase 4 - Documentation, Governance, and Repo Operations | `https://github.com/itprodirect/exai-insurance-intel/issues/15` | `docs/sessions/2026-03-10-roadmap-baseline.md` |
 | `#16 Extend CI/security hardening and document integration follow-ons` | Task | `Phase 3 - Domain/Productization` | `type:task`, `area:ops`, `priority:p1`, `status:ready` | In progress | `#15, #14` | Phase 3 - Domain Coverage and Productization | `https://github.com/itprodirect/exai-insurance-intel/issues/16` | `docs/sessions/2026-03-21-payload-boundary-cleanup.md` |
-| `#17 Maintain roadmap, issue tracker, ADRs, and session notes` | Task | `Phase 3 - Domain/Productization` | `type:task`, `area:docs`, `priority:p0`, `status:ready` | In progress | `#15` | Phase 4 - Documentation, Governance, and Repo Operations | `https://github.com/itprodirect/exai-insurance-intel/issues/17` | `docs/sessions/2026-04-11-issue-17-phase5-tracker-sync.md` |
+| `#17 Maintain roadmap, issue tracker, ADRs, and session notes` | Task | `Phase 3 - Domain/Productization` | `type:task`, `area:docs`, `priority:p0`, `status:ready` | In progress | `#15` | Phase 4 - Documentation, Governance, and Repo Operations | `https://github.com/itprodirect/exai-insurance-intel/issues/17` | `docs/sessions/2026-04-12-issue-17-docs-truth-sync.md` |
 | `#18 Upgrade README with feature matrix, architecture diagram, and roadmap links` | Task | `Phase 3 - Domain/Productization` | `type:task`, `area:docs`, `priority:p1`, `status:ready` | Closed | `#15` | Phase 4 - Documentation, Governance, and Repo Operations | `https://github.com/itprodirect/exai-insurance-intel/issues/18` | `docs/sessions/2026-03-18-phase2-parallel-slices.md` |
 
 ## Phase 5 - Pilot Web Product
@@ -45,7 +45,7 @@ Update it whenever issues are created, closed, re-scoped, or moved between miles
 | `#20 Thin FastAPI wrapper over existing workflows` | Task | `Phase 5 - Pilot` | `type:task`, `area:api`, `priority:p0`, `status:done` | Done | `#19` | Phase 5 Level 1 | TBD | `docs/sessions/2026-03-22-api-wrapper.md` |
 | `#21 Frontend app shell (Next.js + Tailwind + shadcn/ui)` | Task | `Phase 5 - Pilot` | `type:task`, `area:frontend`, `priority:p0`, `status:done` | Done | `#19, #20` | Phase 5 Level 1 | TBD | `docs/sessions/2026-03-22-frontend-shell.md` |
 | `#22 Pilot auth + request/budget boundary controls` | Task | `Phase 5 - Pilot` | `type:task`, `area:auth`, `priority:p0`, `status:done` | Done | `#19, #20` | Phase 5 Level 1 | TBD | `docs/sessions/2026-04-11-issue-22-run-pagination-bounds.md` |
-| `#23 Persistence/state baseline (S3 artifacts + Postgres usage)` | Task | `Phase 5 - Pilot` | `type:task`, `area:infra`, `priority:p1`, `status:next` | Next | `#19, #20` | Phase 5 Level 1 | TBD | `docs/sessions/2026-04-11-issue-23-artifact-location-origin.md` |
+| `#23 Persistence/state baseline (S3 artifacts + Postgres usage)` | Task | `Phase 5 - Pilot` | `type:task`, `area:infra`, `priority:p1`, `status:ready` | In progress | `#19, #20` | Phase 5 Level 1 | TBD | `docs/sessions/2026-04-12-issue-17-docs-truth-sync.md` |
 
 ### Next Coding Slices (Sequenced)
 
@@ -54,7 +54,7 @@ These are the immediate next implementation tasks, in recommended execution orde
 1. ~~**Slice 1: Thin API wrapper** (`#20`)~~ — Done. FastAPI app at `src/exa_demo/api.py` with 5 POST endpoints + health. 9 smoke-mode tests.
 2. ~~**Slice 2: Frontend app shell** (`#21`)~~ — Done. Next.js app in `frontend/` with search, answer, research panels. Server-side proxy to backend.
 3. ~~**Slice 3: Pilot auth + boundary controls** (`#22`)~~ — Done. Owner-or-ops record access, multi-user rate-limit isolation, saved-query input bounds, and run-pagination bounds are shipped.
-4. **Slice 4: Persistence baseline** (`#23`) — Current next slice. S3 artifact storage for run outputs, Postgres for usage/state tracking, migration from local-only SQLite for pilot environments.
+4. **Slice 4: Persistence baseline** (`#23`) - In progress. S3 artifact-location persistence and Postgres repository/factory coverage are merged; remaining work should continue tightening the pilot persistence baseline without widening into deployment or infra rollout.
 
 Each slice should be one focused agent session. See [agent-execution-defaults.md](./agent-execution-defaults.md) for session rules.
 

--- a/docs/pilot-architecture-decision.md
+++ b/docs/pilot-architecture-decision.md
@@ -6,14 +6,19 @@ This document records the near-term architectural defaults for the pilot web pro
 
 ## Current State
 
-The repo is a fully implemented **backend workflow engine** with:
+The repo is a fully implemented **backend workflow engine plus Phase 5 Level 1 pilot surface** with:
 - 8 CLI commands covering all Exa API endpoints
+- FastAPI API layer wrapping the shipped workflows
+- Next.js frontend for search, answer, and research flows
+- Pilot auth and request-boundary controls for bearer auth, per-user scoping, and bounded usage
+- Additive persistence baseline work: local SQLite by default plus S3/Postgres adapters for pilot environments
+- In-process async research jobs backed by persisted run metadata
 - SQLite caching with budget enforcement
 - Evaluation taxonomy and benchmark suites
 - Artifact export system
 - Comprehensive test suite
 
-There is no web frontend, no HTTP API layer, no container deployment, and no production database.
+There is still no container or cloud deployment, no infrastructure automation baseline, and no production-hardened external access model.
 
 ## Target: Private Internal Pilot
 
@@ -74,7 +79,7 @@ A working web product that internal users can use to run insurance intelligence 
 
 ### Async Jobs
 
-Long-running async jobs are **not required for the first pilot** unless testing reveals that research or comparison workflows consistently exceed reasonable HTTP timeout thresholds. If needed, the simplest path is a background task queue (e.g., FastAPI BackgroundTasks or a simple Redis/Celery setup), not a full job orchestration system.
+The repo now includes a minimal in-process async research-job path backed by persisted run records. That is sufficient for the current pilot slice; if reliability or throughput demands grow, the next step should still be a simple background task queue rather than a full job orchestration system.
 
 ## What This Does NOT Decide
 

--- a/docs/sessions/2026-04-12-issue-17-docs-truth-sync.md
+++ b/docs/sessions/2026-04-12-issue-17-docs-truth-sync.md
@@ -1,0 +1,55 @@
+# Session: Issue 17 docs truth sync
+
+- Date: 2026-04-12
+- Participants: Codex, user
+- Related roadmap items: `#17`, `#23`
+- Related ADRs: none
+
+## Context
+
+Take a narrow docs-only governance slice after the latest Phase 5 merges so the top-level docs match the live repo state on `main`.
+
+## Repo Facts Observed
+
+- PR #37 landed the first `#23` persistence slice for artifact-location persistence.
+- PR #38 landed the prior `#17` tracker sync that already marked local Phase 5 `#22` as done.
+- PR #39 landed targeted Postgres repository and factory success-path coverage for the persistence baseline.
+- `README.md` still claimed there was no authentication or multi-user support and still framed persistence as local-only SQLite.
+- `docs/pilot-architecture-decision.md` still described the repo as having no web frontend and no HTTP API layer.
+- `docs/issue-tracker.md` still described local Phase 5 `#23` as an untouched next slice instead of an in-progress baseline.
+- `docs/roadmap.md` was checked and already reflected local Phase 5 `#22` as done and `#23` as current, so it did not need changes.
+
+## Decisions Made
+
+- Keep this as a docs-only truth-sync under `#17`.
+- Update the README so it acknowledges the shipped pilot auth/request-boundary work and additive S3/Postgres persistence adapters without overstating deployment readiness.
+- Update the tracker so local Phase 5 `#23` reads as in progress and the `#17` / `#23` session pointers move forward to this note.
+- Update the pilot architecture note so its current-state and async-job sections match the shipped Phase 5 pilot surface.
+
+## Issues Opened or Updated
+
+- `#17 Maintain roadmap, issue tracker, ADRs, and session notes` - advanced with a narrow post-merge truth sync.
+- Local tracker item `#23` - wording updated from untouched next work to in-progress persistence baseline work.
+
+## Docs Touched
+
+- `README.md`
+- `docs/issue-tracker.md`
+- `docs/pilot-architecture-decision.md`
+- `docs/sessions/2026-04-12-issue-17-docs-truth-sync.md`
+
+## Tests and Checks Run
+
+- `python -m ruff check .`
+- `python -m pytest -q`
+
+## Outcome
+
+- The README, tracker, and pilot architecture note now match the live repo state after PRs #37, #38, and #39.
+- The docs now reflect that pilot auth/request-boundary work exists, additive S3/Postgres persistence work exists, and deployment/cloud rollout still does not.
+- The roadmap needed no change because the relevant Phase 5 status rows were already correct on `main`.
+
+## Next-Session Handoff
+
+- Keep any follow-on `#23` work narrow and implementation-focused rather than reopening broad docs cleanup.
+- If more docs drift appears after additional persistence slices land, update the relevant session pointers instead of rewriting tracker structure.


### PR DESCRIPTION
## Summary
- sync the README with the live Phase 5 pilot state after PRs #37, #38, and #39
- update the local Phase 5 tracker so `#23` reads as in progress instead of untouched next work
- refresh the pilot architecture note's current-state and async-job framing
- add a new `#17` session note for this docs-only truth-sync slice

## What Changed
- acknowledged shipped pilot auth/request-boundary work and additive S3/Postgres persistence adapters in `README.md`
- updated `docs/issue-tracker.md` session pointers and `#23` wording/status
- updated `docs/pilot-architecture-decision.md` to reflect the shipped API, frontend, auth/boundary work, in-process async jobs, and partial persistence baseline
- added `docs/sessions/2026-04-12-issue-17-docs-truth-sync.md`

## Main-Branch Truth Check
- `docs/issue-tracker.md` already had local `#22` marked done on `main`
- `docs/roadmap.md` already had local `#22` done and `#23` current, so it was inspected but not changed

## Validation
- `python -m ruff check .`
- `python -m pytest -q`