### PR TITLE
docs: sync local smoke validation workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ Exa-powered **insurance intelligence toolkit** for CAT-loss, claims, expert, con
 
 ## What This Repo Is Today
 
-This repo is a **backend workflow engine, API, and pilot web UI** for insurance intelligence. All core intelligence workflows (ranked search, cited answers, research reports, structured extraction, seed-URL discovery, benchmark evaluation) are fully implemented, tested, and runnable from the CLI, Jupyter notebook, FastAPI server, and Next.js frontend.
+This repo is an **installable Python package and CLI workflow engine** with a thin FastAPI backend and a pilot Next.js web UI for insurance intelligence.
 
 **What exists:**
-- Complete CLI with 8 commands covering all Exa API endpoints
-- FastAPI server wrapping all workflows as JSON endpoints
-- Next.js frontend with search, answer, and research workflow UIs
+- Python package + CLI workflows for search, answer, research, structured extraction, find-similar, evaluation, comparison, and budget inspection
+- FastAPI backend wrapping the shipped workflows as JSON endpoints
+- Next.js frontend with Search, Answer, Research, and My Work surfaces
 - Pilot auth and request-boundary controls for bearer auth, per-user scoping, and bounded usage
 - SQLite caching with budget enforcement and cost ledger
 - Additive persistence adapters for local SQLite plus pilot S3/Postgres backends
@@ -27,6 +27,28 @@ This repo is a **backend workflow engine, API, and pilot web UI** for insurance 
 
 This repo stays intentionally lean while supporting repeatable notebook and CLI workflows for insurance research, cited answers, structured extraction, and report generation.
 
+## Current Local Status (Validated 2026-04-12)
+
+This session revalidated the **local smoke/mock path** end to end.
+
+Validated now:
+- Isolated virtual environment rebuild
+- `python -m pip install --no-user -e '.[dev,api]'`
+- `python -m pytest -q`
+- `python -m ruff check .`
+- `python scripts/run_live_validation.py --mode smoke`
+- Local FastAPI startup with `uvicorn exa_demo.api:app --reload`
+- Local backend checks at `http://127.0.0.1:8000/health` and `http://127.0.0.1:8000/docs`
+- Local frontend startup from `frontend/` with `npm install` and `npm run dev`
+- Browser validation for Search, Answer, Research, and My Work against the local backend
+
+Still not validated in this session:
+- `--mode live` or real Exa API traffic
+- S3 artifact storage or Postgres-backed usage/run persistence
+- Production readiness or deployed environments
+
+Use [docs/local-validation.md](docs/local-validation.md) for the exact reproduction steps.
+
 Core local resources:
 - one core notebook: `exa_people_search_eval.ipynb`
 - one local env file: `.env` (not committed)
@@ -37,10 +59,12 @@ Core local resources:
 - [What this repo evaluates](#what-this-repo-evaluates)
 - [Feature matrix](#feature-matrix)
 - [Architecture](#architecture)
-- [Windows 11 setup](#windows-11-setup-python-310)
+- [Current local status](#current-local-status-validated-2026-04-12)
+- [Local setup](#local-setup-powershell-or-git-bash-python-310)
 - [CLI commands](#cli-commands)
 - [API server](#api-server)
 - [Frontend](#frontend)
+- [Local validation runbook](#local-validation-runbook)
 - [Experiment artifacts](#experiment-artifacts)
 - [Demo gallery](#demo-gallery)
 - [Integration boundaries](#integration-boundaries)
@@ -61,7 +85,7 @@ Core local resources:
 | Seed-URL discovery | Done | `python -m exa_demo find-similar` | `find_similar.json` | Separate `/findSimilar` workflow and normalization path |
 | Cache and budget ledger | Done | Notebook + CLI | `exa_cache.sqlite`, `summary.json` | Prevents re-billing on cache hits |
 | API server | Done | `uvicorn exa_demo.api:app` | JSON responses | Thin FastAPI wrapper over CLI workflows; smoke mode first-class |
-| Frontend UI | Done | `npm run dev` in `frontend/` | Browser UI | Next.js + TypeScript + Tailwind + shadcn/ui; search, answer, research |
+| Frontend UI | Done | `npm run dev` in `frontend/` | Browser UI | Next.js + TypeScript + Tailwind + shadcn/ui; search, answer, research, My Work |
 | Smoke CI and local tests | Done | GitHub Actions + `pytest -q` | CI runs and local test suite | Default workflow runs `pytest` and notebook smoke |
 
 ## Architecture
@@ -116,54 +140,57 @@ Optional for before/after reporting in notebook Cell 9:
 - `CONFIG["compare_to_run_id"] = "<baseline-run-id>"`
 - `CONFIG["compare_base_dir"] = "experiments"`
 
-## Windows 11 Setup (Python 3.10+)
+## Local Setup (PowerShell or Git Bash, Python 3.10+)
 
-1. Open PowerShell in this repo.
-2. Create venv:
+1. Create the virtual environment:
 
 ```powershell
-py -3.10 -m venv .venv
+python -m venv .venv
 ```
 
-3. Activate:
+2. Activate it.
+
+PowerShell:
 
 ```powershell
 .\.venv\Scripts\Activate.ps1
 ```
 
-4. Install dependencies:
+Git Bash:
+
+```bash
+source .venv/Scripts/activate
+```
+
+3. Install the package, CLI, API extra, and dev tooling:
 
 ```powershell
 python -m pip install --upgrade pip
-pip install -r requirements.txt
+python -m pip install --no-user -e '.[dev,api]'
 ```
 
-
-## Installable Package and CLI
-
-For an editable install with the CLI and dev tools available:
-
-```powershell
-pip install -e ".[dev]"
-```
-
-If your environment blocks build-dependency downloads, use:
-
-```powershell
-pip install -e ".[dev]" --no-build-isolation
-```
-
-Optional local hooks:
+4. Optional local hooks:
 
 ```powershell
 pre-commit install
 ```
+
+If package installation or editable installs land outside `.venv`, reactivate the environment and prefer `python -m pip ...` over bare `pip ...`. The safest quick check is `python -c "import sys; print(sys.executable)"`, which should point at `.venv`.
+
 ## Configure Environment
 
 Create `.env` from template:
 
+PowerShell:
+
 ```powershell
 Copy-Item .env.example .env
+```
+
+Git Bash:
+
+```bash
+cp .env.example .env
 ```
 
 Edit `.env`:
@@ -177,7 +204,8 @@ EXA_SMOKE_NO_NETWORK=0
 
 Notes:
 - `.env` is ignored by git.
-- If you want no-network testing, use smoke mode (`EXA_SMOKE_NO_NETWORK=1` or runner `--mode smoke`).
+- The validated local path in this README stays on `--mode smoke`, so a real API key is not required unless you intentionally switch to live mode.
+- `EXA_SMOKE_NO_NETWORK=1` is the safest env-level default if you want no-network behavior even when a command omits `--mode smoke`.
 
 ## Run Notebook
 
@@ -201,7 +229,7 @@ Notebook flow is intentionally fixed to 9 cells:
 python -m exa_demo search "forensic engineer insurance expert witness" --mode smoke --json
 python -m exa_demo answer "What is the Florida appraisal clause dispute process?" --mode smoke --json
 python -m exa_demo research "Summarize the Florida CAT market outlook." --mode smoke --json
-python -m exa_demo structured-search "independent adjuster florida catastrophe claims" --schema-file .\path\to\structured-schema.json --mode smoke --json
+python -m exa_demo structured-search "independent adjuster florida catastrophe claims" --schema-file path/to/structured-schema.json --mode smoke --json
 python -m exa_demo find-similar "https://example.com/florida-appraisal-decision" --mode smoke --json
 python -m exa_demo search "Florida property insurance appraisal clause" --type deep --additional-query "Florida appraisal dispute statute" --start-published-date 2025-01-01 --livecrawl --json
 python -m exa_demo eval --mode smoke --suite forensic_and_damage_engineering --limit 5 --json
@@ -230,11 +258,7 @@ When comparison is enabled, the run also writes a human-readable `experiments/<R
 
 ## API Server
 
-The API is a thin FastAPI wrapper over the same workflow functions the CLI uses. Install with the `api` extra:
-
-```powershell
-pip install -e ".[api]"
-```
+The API is a thin FastAPI wrapper over the same workflow functions the CLI uses. If you followed the local setup above, the `api` extra is already installed.
 
 Start the server:
 
@@ -242,7 +266,11 @@ Start the server:
 uvicorn exa_demo.api:app --reload
 ```
 
-The server runs on `http://127.0.0.1:8000` by default. Interactive docs are at `/docs`.
+The server runs on `http://127.0.0.1:8000` by default.
+
+Useful local URLs:
+- `http://127.0.0.1:8000/health`
+- `http://127.0.0.1:8000/docs`
 
 ### Endpoints
 
@@ -272,6 +300,19 @@ The frontend is a Next.js app in `frontend/` that calls the FastAPI backend thro
 ```powershell
 cd frontend
 npm install
+```
+
+Copy the frontend env file:
+
+PowerShell:
+
+```powershell
+Copy-Item .env.local.example .env.local
+```
+
+Git Bash:
+
+```bash
 cp .env.local.example .env.local
 ```
 
@@ -296,12 +337,17 @@ Open `http://localhost:3000`. The frontend proxies API calls to the backend at `
 
 - Health indicator showing backend connection status
 - Tab-based workflow selector (Search, Answer, Research)
+- My Work view showing newly created runs
 - Search: query input, result count, taxonomy scores, result cards with highlights
 - Answer: question input, cited answer display with source links
 - Research: topic input, report display with sources
 - Loading spinners and error handling on all workflows
 
-All workflows default to smoke mode — no API key or network needed for frontend development.
+The local UI validation in this session stayed on the smoke/mock path. Live Exa mode, S3 artifact storage, and Postgres-backed persistence were not exercised through the frontend.
+
+## Local Validation Runbook
+
+Follow [docs/local-validation.md](docs/local-validation.md) for the exact smoke-path reproduction flow used in this session.
 
 ## Benchmark Fixture
 
@@ -358,14 +404,15 @@ Use [docs/integration-boundaries.md](docs/integration-boundaries.md) for the cur
 
 Use the manual GitHub Actions workflow in [.github/workflows/live-validation.yml](.github/workflows/live-validation.yml) when you want a deliberate real-API validation pass against the shipped CLI workflows.
 
-Local dry run:
+Local smoke dry run:
 
 ```powershell
-python .\scripts\run_live_validation.py --mode smoke
+python scripts/run_live_validation.py --mode smoke
 ```
 
 Guidance:
 - default to `--mode smoke` locally unless you are intentionally validating live API behavior
+- the current local validation captured in this README did **not** exercise live mode
 - the manual workflow is bounded by design and uploads runtime artifacts for review
 - `--include-comparison` is optional because it is materially more expensive than the default endpoint checks
 
@@ -379,27 +426,34 @@ Guidance:
 Reset cache safely:
 
 ```powershell
-python .\scripts\reset_cache.py
+python scripts/reset_cache.py
 ```
 
 Skip prompt:
 
 ```powershell
-python .\scripts\reset_cache.py --yes
+python scripts/reset_cache.py --yes
 ```
 
 ## Smoke Runner (nbclient)
 
 ```powershell
-python .\scripts\run_notebook_smoke.py --mode smoke
+python scripts/run_notebook_smoke.py --mode smoke
 ```
+
+This notebook smoke runner remains available, but it was not part of the local frontend/backend validation path rechecked on 2026-04-12.
 
 ## Local Quality Gate
 
+Validated in this session:
 - `python -m ruff check .`
 - `python -m pytest -q`
-- `pre-commit run --all-files`
 - `python scripts/run_live_validation.py --mode smoke`
+- `uvicorn exa_demo.api:app --reload`
+- `npm install` and `npm run dev` in `frontend/`
+
+Optional extra check:
+- `pre-commit run --all-files`
 
 Modes:
 - `--mode smoke`: forced no-network run (default)
@@ -413,7 +467,7 @@ Recommended boundary:
 Optional timeout override:
 
 ```powershell
-python .\scripts\run_notebook_smoke.py --mode smoke --timeout 180
+python scripts/run_notebook_smoke.py --mode smoke --timeout 180
 ```
 
 ## Safe Cost Tuning
@@ -461,7 +515,7 @@ For a from-scratch architecture critique and refactor roadmap, see `docs/rebuild
 - GitHub issue tracker mapping: [docs/issue-tracker.md](docs/issue-tracker.md)
 - ADR index: [docs/adr/README.md](docs/adr/README.md)
 - Session note template: [docs/sessions/README.md](docs/sessions/README.md)
-- Latest implementation session: [docs/sessions/2026-04-12-issue-17-docs-truth-sync.md](docs/sessions/2026-04-12-issue-17-docs-truth-sync.md)
+- Latest implementation session: [docs/sessions/2026-04-12-local-smoke-validation-doc-sync.md](docs/sessions/2026-04-12-local-smoke-validation-doc-sync.md)
 
 ## Guardrails
 
@@ -470,4 +524,3 @@ For a from-scratch architecture critique and refactor roadmap, see `docs/rebuild
 - No contact harvesting
 - Redaction stays enabled in notebook output
 - Human review required before operational use
-

--- a/docs/demo-gallery.md
+++ b/docs/demo-gallery.md
@@ -39,7 +39,7 @@ python -m exa_demo research "Summarize the Florida CAT market outlook." --mode s
 `structured-search` is the schema-driven extraction workflow. Use it when you want Exa to return a typed payload that can be normalized into downstream tables, graphs, or datasets.
 
 ```powershell
-python -m exa_demo structured-search "independent adjuster florida catastrophe claims" --schema-file .\path\to\structured-schema.json --mode smoke --json
+python -m exa_demo structured-search "independent adjuster florida catastrophe claims" --schema-file path/to/structured-schema.json --mode smoke --json
 ```
 
 ## Comparison

--- a/docs/integration-boundaries.md
+++ b/docs/integration-boundaries.md
@@ -14,6 +14,14 @@ This repo is designed to stay safe-by-default while still supporting deliberate 
 - Use `live` only for explicit manual validation when you want to inspect real API behavior.
 - Keep human review in the loop for any operational interpretation of results, even in `live`.
 
+## Current Locally Validated Path (2026-04-12)
+
+- Rebuilt an isolated virtual environment and installed with `python -m pip install --no-user -e '.[dev,api]'`
+- Passed `python -m pytest -q`, `python -m ruff check .`, and `python scripts/run_live_validation.py --mode smoke`
+- Booted the FastAPI app locally and verified `/health` and `/docs`
+- Booted the Next.js frontend locally and verified Search, Answer, Research, and My Work against the local backend
+- Did **not** revalidate `live` mode, S3 artifact storage, or Postgres-backed usage/run persistence
+
 ## Artifact Expectations
 
 - Smoke runs preserve the same artifact shape as live runs whenever possible.
@@ -52,8 +60,8 @@ This section clarifies what belongs in the repo now versus what should be deferr
 | CLI + notebook interfaces | Existing user surfaces |
 | SQLite cache + budget ledger | Local dev and smoke mode persistence |
 | Benchmark fixtures and evaluation | Domain-specific; tightly coupled to workflows |
-| Thin FastAPI wrapper (next) | Thin adapter over existing workflows; belongs with the code it wraps |
-| Frontend app (next) | Product UI; lives in-repo as `frontend/` or similar until scale demands separation |
+| Thin FastAPI wrapper | Thin adapter over existing workflows; belongs with the code it wraps |
+| Frontend app | Product UI; lives in-repo as `frontend/` until scale demands separation |
 
 ### Deferred to platform / infra layers
 
@@ -69,6 +77,7 @@ This section clarifies what belongs in the repo now versus what should be deferr
 ### Boundary rules
 
 - Do not add infrastructure-as-code to the repo until the pilot architecture is validated with real users.
-- Keep the API wrapper thin — it should delegate to existing workflow functions, not duplicate logic.
+- Keep the API wrapper thin - it should delegate to existing workflow functions, not duplicate logic.
 - Frontend and backend can share a monorepo during pilot. Separation is a Level 3 concern.
 - Auth should start as simple middleware in the API layer, not as a separate service.
+- Do not blur additive S3/Postgres code paths with the current validated local smoke path unless they have been explicitly revalidated end to end.

--- a/docs/local-validation.md
+++ b/docs/local-validation.md
@@ -1,0 +1,138 @@
+# Local Validation Runbook
+
+This runbook captures the repo's **current validated local state** as rechecked on **2026-04-12**.
+
+## Validated Today
+
+- Rebuilt and activated an isolated Python virtual environment
+- Installed the package and extras with `python -m pip install --no-user -e '.[dev,api]'`
+- Passed `python -m pytest -q`
+- Passed `python -m ruff check .`
+- Passed `python scripts/run_live_validation.py --mode smoke`
+- Booted the FastAPI app locally with `uvicorn exa_demo.api:app --reload`
+- Verified `http://127.0.0.1:8000/health`
+- Verified `http://127.0.0.1:8000/docs`
+- Booted the frontend locally from `frontend/` with `npm install` and `npm run dev`
+- Verified frontend-to-backend connectivity at `http://localhost:3000`
+- Verified Search, Answer, Research, and My Work through the UI
+
+## Not Validated Today
+
+- Live Exa mode (`--mode live`)
+- Real Exa API billing or live result quality
+- S3 artifact storage
+- Postgres-backed usage or run persistence
+- Production deployment, production readiness, or infrastructure rollout
+
+## Reproduce The Local Smoke Path
+
+1. Create and activate the virtual environment.
+
+PowerShell:
+
+```powershell
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+```
+
+Git Bash:
+
+```bash
+python -m venv .venv
+source .venv/Scripts/activate
+```
+
+2. Install the package, dev tooling, and FastAPI dependencies.
+
+```powershell
+python -m pip install --upgrade pip
+python -m pip install --no-user -e '.[dev,api]'
+```
+
+3. Copy the backend env file.
+
+PowerShell:
+
+```powershell
+Copy-Item .env.example .env
+```
+
+Git Bash:
+
+```bash
+cp .env.example .env
+```
+
+4. Run the validated Python checks.
+
+```powershell
+python -m pytest -q
+python -m ruff check .
+python scripts/run_live_validation.py --mode smoke
+```
+
+5. Start the backend.
+
+```powershell
+uvicorn exa_demo.api:app --reload
+```
+
+Check:
+- `http://127.0.0.1:8000/health`
+- `http://127.0.0.1:8000/docs`
+
+6. Start the frontend in a second terminal.
+
+```powershell
+cd frontend
+npm install
+```
+
+Copy the frontend env file.
+
+PowerShell:
+
+```powershell
+Copy-Item .env.local.example .env.local
+```
+
+Git Bash:
+
+```bash
+cp .env.local.example .env.local
+```
+
+Start the frontend:
+
+```powershell
+npm run dev
+```
+
+Open `http://localhost:3000`.
+
+7. Recheck the validated UI flow.
+
+- Run Search
+- Run Answer
+- Run Research
+- Confirm My Work shows the new runs
+
+## Boundary Notes
+
+- The validated path above is still **local + smoke/mock only**.
+- Do not treat the current docs as evidence that live Exa mode was revalidated.
+- Do not treat the current docs as evidence that S3 or Postgres-backed persistence was exercised end to end.
+- Treat deployment and production hardening as future work, not current state.
+
+## Troubleshooting
+
+If `pip` appears to install outside `.venv`, reactivate the virtual environment and use `python -m pip` instead of bare `pip`.
+
+Useful checks:
+
+```powershell
+python -c "import sys; print(sys.executable)"
+python -m pip --version
+```
+
+Both should point at the active `.venv` before you install dependencies.

--- a/docs/pilot-architecture-decision.md
+++ b/docs/pilot-architecture-decision.md
@@ -7,7 +7,7 @@ This document records the near-term architectural defaults for the pilot web pro
 ## Current State
 
 The repo is a fully implemented **backend workflow engine plus Phase 5 Level 1 pilot surface** with:
-- 8 CLI commands covering all Exa API endpoints
+- 8 CLI commands covering the shipped repo workflows
 - FastAPI API layer wrapping the shipped workflows
 - Next.js frontend for search, answer, and research flows
 - Pilot auth and request-boundary controls for bearer auth, per-user scoping, and bounded usage
@@ -19,6 +19,10 @@ The repo is a fully implemented **backend workflow engine plus Phase 5 Level 1 p
 - Comprehensive test suite
 
 There is still no container or cloud deployment, no infrastructure automation baseline, and no production-hardened external access model.
+
+## Current Local Validation Note
+
+As of 2026-04-12, the repo has been revalidated locally on the smoke/mock path: isolated venv install, `pytest`, `ruff`, `python scripts/run_live_validation.py --mode smoke`, local FastAPI boot (`/health`, `/docs`), and local frontend Search/Answer/Research/My Work. Live Exa mode and S3/Postgres-backed persistence were not revalidated in that session.
 
 ## Target: Private Internal Pilot
 
@@ -44,9 +48,9 @@ A working web product that internal users can use to run insurance intelligence 
 | Framework | FastAPI | Lightweight; async-capable; good OpenAPI generation |
 | Pattern | Thin wrapper over existing workflow functions | No logic duplication; one endpoint per CLI command |
 | Response format | JSON matching existing artifact schemas | Frontend consumes the same shapes the CLI produces |
-| Smoke mode | Supported via query param or config | Frontend dev works without Exa API key |
+| Smoke mode | Supported via request mode plus config | Frontend dev works without Exa API key |
 | Deploy direction | AWS-compatible service path (ECS/Lambda) | Standard; team-familiar; can start with single instance |
-| Repo location | `api/` directory or extend `src/exa_demo/` | Keep close to workflow code it wraps |
+| Repo location | `src/exa_demo/` | Keep the API close to the workflow code it wraps |
 
 ### Persistence
 
@@ -55,7 +59,7 @@ A working web product that internal users can use to run insurance intelligence 
 | Artifact storage | S3 (or S3-compatible) | Durable; cheap; existing artifact shapes map directly |
 | Relational state | Postgres | Usage tracking, user state, run metadata |
 | Local dev cache | Keep existing SQLite | Works; no reason to change for local/smoke mode |
-| Migration approach | Additive — S3 and Postgres supplement SQLite, not replace it | SQLite stays for CLI/notebook; pilot adds cloud persistence |
+| Migration approach | Additive - S3 and Postgres supplement SQLite, not replace it | SQLite stays for CLI/notebook; pilot adds cloud persistence |
 
 ### Auth and Controls
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -67,19 +67,19 @@ This phase governs how roadmap work is tracked and how delivery history is prese
 | Governance and delivery tracking | Maintain roadmap, issue tracker, ADRs, and session notes as durable project history | Preserves why decisions were made and what changed each session | `In progress` | None | Docs and GitHub stay in sync for roadmap items and active work | [#17](https://github.com/itprodirect/exai-insurance-intel/issues/17) |
 | README alignment and top-level navigation | Keep the README synchronized with the actual repo baseline, roadmap, and governance docs | Makes the repo entry point accurate for future sessions and contributors | `Done` | Governance conventions | README links, feature framing, and architecture context stay aligned with the roadmap | [#18](https://github.com/itprodirect/exai-insurance-intel/issues/18) |
 
-## Planned Interfaces and Contracts
+## Interfaces and Contracts
 
-These interfaces are intentionally documented now so future implementation work has a stable target.
+These interfaces are implemented and documented here so future work has a stable current reference point.
 
 ### CLI contract
 
-Planned commands:
+Current commands:
 
 ```powershell
 python -m exa_demo search "public adjuster Florida hurricane"
 python -m exa_demo answer "What is the Florida appraisal clause dispute process?"
 python -m exa_demo research "Summarize the Florida CAT market outlook."
-python -m exa_demo structured-search "independent adjuster florida catastrophe claims" --schema-file .\path\to\structured-schema.json
+python -m exa_demo structured-search "independent adjuster florida catastrophe claims" --schema-file path/to/structured-schema.json
 python -m exa_demo find-similar "https://example.com/florida-appraisal-decision"
 python -m exa_demo eval --suite insurance
 python -m exa_demo compare-search-types --suite forensic_and_damage_engineering --baseline-type deep --candidate-type deep-reasoning
@@ -88,13 +88,13 @@ python -m exa_demo budget --run-id demo-2026-03
 
 ### Model contract
 
-Planned module:
+Current module:
 
 ```text
 src/exa_demo/models.py
 ```
 
-Planned responsibilities:
+Current responsibilities:
 
 - normalized Exa result records
 - cost breakdown and ledger records
@@ -103,7 +103,7 @@ Planned responsibilities:
 
 ### Experiment artifact contract
 
-Planned run layout:
+Current run layout:
 
 ```text
 experiments/<run-id>/config.json
@@ -131,12 +131,14 @@ See [pilot-architecture-decision.md](./pilot-architecture-decision.md) for the l
 
 Goal: a working web UI that internal users can use to run existing workflows through a browser instead of the CLI.
 
+Current local validation remains smoke/local only. Live Exa mode and S3/Postgres-backed runtime validation are still future work under the persistence baseline row below.
+
 | Roadmap item | Goal | Why it matters | Current status | Dependencies | Success criteria | GitHub issue |
 | --- | --- | --- | --- | --- | --- | --- |
 | Thin API wrapper | Expose existing workflows as FastAPI endpoints | Decouples frontend from Python CLI; enables web product path | `Done` | Phase 1-4 baseline | FastAPI app serves search, answer, research, find-similar, structured-search over HTTP with JSON responses | TBD |
 | Frontend app shell | Next.js + TypeScript + Tailwind + shadcn/ui scaffold with App Router | Establishes the frontend stack and deploy target | `Done` | Thin API wrapper | App shell renders, routes work, can call API endpoints | TBD |
 | Pilot auth + request boundary | Internal-only auth, request validation, rate limiting, budget guardrails, request logging | Prevents uncontrolled usage before the product is hardened | `Done` | Thin API wrapper | Only authenticated internal users can make requests; spend is bounded and logged | TBD |
-| Persistence baseline | Artifacts in S3, relational state/usage in Postgres, existing SQLite cache kept for local dev | Moves beyond local-only SQLite for pilot durability | `Current` | Thin API wrapper | Pilot runs persist artifacts to S3 and track usage in Postgres | TBD |
+| Persistence baseline | Artifacts in S3, relational state/usage in Postgres, existing SQLite cache kept for local dev | Moves beyond local-only SQLite for pilot durability | `In progress` | Thin API wrapper | Target state: pilot runs persist artifacts to S3 and track usage in Postgres after explicit end-to-end validation | TBD |
 
 ### Level 2 - Limited External Beta
 
@@ -174,5 +176,3 @@ These are preserved as future exploration themes, but they are not committed bac
 - [Improvement roadmap](./exai-insurance-intel-improvements.md)
 - [docs/rebuild_review.md](./rebuild_review.md)
 - Current repository code, tests, CI, and README baseline observed on March 10, 2026
-
-

--- a/docs/sessions/2026-04-12-local-smoke-validation-doc-sync.md
+++ b/docs/sessions/2026-04-12-local-smoke-validation-doc-sync.md
@@ -1,0 +1,30 @@
+# Session: Local smoke validation doc sync
+
+Date: 2026-04-12
+Type: docs-only
+Related issue: #17
+
+## Goal
+
+Update the docs so they reflect the repo's current validated local smoke path without overstating live-mode, persistence, or production status.
+
+## What Changed
+
+- Updated `README.md` to:
+  - describe the repo as a Python package/CLI plus FastAPI backend and Next.js frontend
+  - add a dated current local status section
+  - replace stale local install commands with the validated `python -m pip install --no-user -e '.[dev,api]'` flow
+  - make setup and env-copy steps friendlier to both PowerShell and Git Bash
+  - point contributors at the exact local smoke validation path and URLs
+  - distinguish validated smoke checks from unvalidated live-mode and S3/Postgres-backed paths
+- Added `docs/local-validation.md` as a focused runbook for reproducing the validated local smoke path.
+- Updated `docs/demo-gallery.md`, `docs/integration-boundaries.md`, `docs/pilot-architecture-decision.md`, and `docs/roadmap.md` so shipped web surfaces are no longer described as "next" and persistence target-state language is clearly separated from what has actually been locally validated.
+
+## Validation
+
+- Docs review only
+- No application code changes
+
+## Outcome
+
+The top-level docs now tell a new contributor how to reproduce the currently validated local smoke path and explicitly call out what remains unvalidated.


### PR DESCRIPTION
## Summary
- update README to reflect the current validated local smoke workflow
- add a focused local validation runbook for backend/frontend smoke-path reproduction
- clarify that live Exa mode and S3/Postgres-backed persistence remain unvalidated in the current local docs state

## Validation
- docs review only
- no application code changes
