### PR TITLE
[codex] expose persistence backend health labels

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,12 @@ EXA_API_KEY=your_exa_api_key_here
 
 # Optional: set to 1 to run local smoke tests without network/API billing.
 EXA_SMOKE_NO_NETWORK=0
+
+# Optional pilot persistence configuration.
+# Keep the defaults for local dev, or switch to postgres/s3 for the pilot path.
+# PILOT_RUN_STORE=local
+# PILOT_RUN_STORE_PATH=pilot_runs.sqlite
+# PILOT_POSTGRES_URL=postgresql://user:password@host:5432/dbname
+# PILOT_ARTIFACT_STORE=local
+# PILOT_S3_BUCKET=your-pilot-bucket
+# PILOT_S3_PREFIX=artifacts/

--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,8 @@ EXA_SMOKE_NO_NETWORK=0
 # Keep the defaults for local dev, or switch to postgres/s3 for the pilot path.
 # PILOT_RUN_STORE=local
 # PILOT_RUN_STORE_PATH=pilot_runs.sqlite
-# PILOT_POSTGRES_URL=postgresql://user:password@host:5432/dbname
+# Real database credentials belong only in local .env files or deployment secrets.
+# PILOT_POSTGRES_URL=postgresql://localhost:5432/exai_pilot
 # PILOT_ARTIFACT_STORE=local
 # PILOT_S3_BUCKET=your-pilot-bucket
 # PILOT_S3_PREFIX=artifacts/

--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -2,12 +2,12 @@
 
 _Generated file. Regenerate with `python scripts/generate_heartbeat.py`._
 
-_Generated: 2026-04-12T02:14:21.887065+00:00_
+_Generated: 2026-04-28T05:21:10.487271+00:00_
 
 ## Current status
 - Purpose: Exa-powered insurance intelligence toolkit for CAT-loss, claims, expert, contractor, and market/regulatory research workflows.
 - Strategic role: Workflow engine plus controlled pilot web-product base for internal insurance-intelligence validation.
-- Current milestone: Phase 5 Level 1 is partially complete: the thin FastAPI wrapper, frontend shell, and pilot auth/request-boundary hardening are shipped, and the persistence baseline is now the active next bounded slice.
+- Current milestone: Phase 5 Level 1 is partially complete: the thin FastAPI wrapper, frontend shell, and pilot auth/request-boundary hardening are shipped, and the persistence baseline is in progress with additive S3/Postgres adapters plus API health self-reporting for selected persistence backends.
 
 ## Operating posture
 - Active Python workflow repo with package code in `src/exa_demo/`, a thin FastAPI app in the same package, and a Next.js frontend in `frontend/`. SQLite cache, budget controls, benchmark fixtures, exported artifacts, and smoke/live execution modes are already in place. Manual live validation is script-backed, but the inspected docs only verify smoke validation runs so far.
@@ -20,12 +20,12 @@ _Generated: 2026-04-12T02:14:21.887065+00:00_
 - Durable memory must stay curated and human-reviewed; heartbeat artifacts are generated sidecars, not the source of truth.
 
 ## Top blockers
-- Phase 5 Level 1 is not complete because the persistence baseline is still missing; local SQLite is present, but the planned S3/Postgres pilot path is not yet implemented.
+- Phase 5 Level 1 is not complete because the persistence baseline still lacks end-to-end S3/Postgres-backed pilot validation and deployment posture; local defaults, pilot adapters, and backend self-reporting are present.
 - GitHub issue numbering has drifted from the local Phase 5 roadmap IDs, so the tracker still has `TBD` GitHub URLs for those items until dedicated issues are created.
-- Docs freshness is mixed because `docs/pilot-architecture-decision.md` and `docs/sessions/2026-03-22-pilot-alignment.md` still describe a pre-slice state with no frontend/API layer, while README and later slice notes show both shipped.
+- Live Exa mode, S3/Postgres-backed runtime behavior, and deployed pilot environments remain unvalidated; the documented validated path is still local smoke mode.
 
 ## Docs + setup
-- Docs freshness: Mixed but workable. `README.md`, `docs/roadmap.md`, `docs/issue-tracker.md`, `docs/integration-boundaries.md`, and the 2026-03-22 implementation session notes reflect the current repo direction; the pilot architecture doc's current-state section and the pilot-alignment note lag behind the shipped API/frontend reality.
+- Docs freshness: Workable. `README.md`, `docs/local-validation.md`, `docs/roadmap.md`, `docs/issue-tracker.md`, `docs/integration-boundaries.md`, and `docs/pilot-architecture-decision.md` reflect the current smoke/local and persistence-in-progress posture; older March session notes remain historical and may describe pre-slice state.
 - Setup friction: Moderate. Python setup is straightforward, but full local work spans Python deps, optional `[api]` extras, a separate `frontend/` npm install and env file, and deliberate handling of smoke versus live mode with `EXA_API_KEY` only for bounded manual validation.
 
 ## Validation path
@@ -37,6 +37,7 @@ _Generated: 2026-04-12T02:14:21.887065+00:00_
 
 ## Key files / commands
 - `README.md`
+- `docs/local-validation.md`
 - `docs/roadmap.md`
 - `docs/issue-tracker.md`
 - `docs/integration-boundaries.md`
@@ -56,25 +57,28 @@ _Generated: 2026-04-12T02:14:21.887065+00:00_
 ## Wait until later
 - Any automatic promotion of generated heartbeat output into durable memory or strategy docs.
 - Scheduled or automatic live validation runs, dashboards, or cross-repo telemetry.
-- Scope beyond this scaffold into auth redesign, persistence implementation, async jobs, deployment, infra, or broader docs refactors.
+- Scope beyond this scaffold into auth redesign, persistence redesign, async jobs, deployment, infra, or broader docs refactors.
 
 ## Last session
-- Date: 2026-04-11e
-- Objective: Take a simple end-of-session docs slice by syncing the local Phase 5 tracker and durable memory to the merged work.
+- Date: 2026-04-28
+- Objective: Close the session with a final docs pass after a narrow Phase 5 persistence-baseline posture slice.
 - Changes made:
-  - Inspected the local tracker, roadmap, heartbeat, and memory snapshot after the merged `#22` and first `#23` slices.
-  - Marked the local Phase 5 `#22` tracker item as done and kept `#23` as the active next slice.
-  - Updated the roadmap and `MEMORY.md` so they reflect that auth/request-boundary hardening is shipped and persistence is now the primary Phase 5 Level 1 blocker.
-  - Documented the Phase 5 numbering drift: local tracker IDs `#19`-`#23` are roadmap/task IDs, while GitHub numbers `22` and `23` are already occupied by older merged PRs.
-  - Added the session note and synced the tracker pointer for `#17`.
+  - Added API health response fields for the selected run and artifact persistence backends.
+  - Kept `/health` and `/api/health` unauthenticated while expanding their response shape.
+  - Added backend-selection logging for local/Postgres run repositories and local/S3 artifact stores.
+  - Added optional `postgres`, `s3`, and aggregate `pilot` extras in `pyproject.toml`.
+  - Documented optional pilot persistence env vars in `.env.example`.
+  - Updated README/local-validation wording, tracker pointers, roadmap wording, durable memory, and the session log for the final closeout.
 - Validation:
-  - No code or test changes; docs-only sync.
+  - `python -m ruff check src/exa_demo/api.py src/exa_demo/persistence.py tests/test_api.py tests/test_api_auth.py` -> passed
+  - `python -m pytest -q tests/test_api.py tests/test_api_auth.py` -> passed (`31 passed`)
+  - `python -m pytest -q tests/test_persistence.py` -> passed (`62 passed`)
 - Open issues:
+  - Local Phase 5 `#23` remains in progress; S3/Postgres-backed pilot behavior still needs explicit end-to-end validation before durability is claimed.
   - Dedicated GitHub issues still need to be created for the local Phase 5 tracker items if the repo wants live issue links instead of `TBD`.
-  - `docs/pilot-architecture-decision.md` and the earlier pilot-alignment note still lag the shipped API/frontend reality.
 - Decisions proposed:
-  - Treat the local Phase 5 tracker IDs as internal roadmap IDs until dedicated GitHub issues are created, instead of linking them to unrelated GitHub numbers.
-  - Keep the next coding work on `#23` persistence slices rather than reopening the completed `#22` boundary track.
+  - Keep backend labels on health responses limited to coarse backend names (`local`, `postgres`, `s3`) and avoid exposing connection details.
+  - Continue persistence-baseline work in thin slices rather than bundling deployment, migrations, or auth redesign into `#23`.
 
 ## Next thin slice
-- Continue `#23` with another small persistence-baseline seam, or end the session here if you want to wind down cleanly.
+- Add one focused `#23` validation seam for configured Postgres/S3 behavior, or stop here and merge this posture slice first.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -32,7 +32,7 @@ Exa-powered insurance intelligence toolkit for CAT-loss, claims, expert, contrac
 Workflow engine plus controlled pilot web-product base for internal insurance-intelligence validation.
 
 ## Current milestone
-Phase 5 Level 1 is partially complete: the thin FastAPI wrapper, frontend shell, and pilot auth/request-boundary hardening are shipped, and the persistence baseline is now the active next bounded slice.
+Phase 5 Level 1 is partially complete: the thin FastAPI wrapper, frontend shell, and pilot auth/request-boundary hardening are shipped, and the persistence baseline is in progress with additive S3/Postgres adapters plus API health self-reporting for selected persistence backends.
 
 ## Durable decisions
 - Markdown docs under `docs/` remain the canonical backlog, architecture, ADR, and session-history surface for this repo.
@@ -45,12 +45,12 @@ Phase 5 Level 1 is partially complete: the thin FastAPI wrapper, frontend shell,
 Active Python workflow repo with package code in `src/exa_demo/`, a thin FastAPI app in the same package, and a Next.js frontend in `frontend/`. SQLite cache, budget controls, benchmark fixtures, exported artifacts, and smoke/live execution modes are already in place. Manual live validation is script-backed, but the inspected docs only verify smoke validation runs so far.
 
 ## Top blockers
-- Phase 5 Level 1 is not complete because the persistence baseline is still missing; local SQLite is present, but the planned S3/Postgres pilot path is not yet implemented.
+- Phase 5 Level 1 is not complete because the persistence baseline still lacks end-to-end S3/Postgres-backed pilot validation and deployment posture; local defaults, pilot adapters, and backend self-reporting are present.
 - GitHub issue numbering has drifted from the local Phase 5 roadmap IDs, so the tracker still has `TBD` GitHub URLs for those items until dedicated issues are created.
-- Docs freshness is mixed because `docs/pilot-architecture-decision.md` and `docs/sessions/2026-03-22-pilot-alignment.md` still describe a pre-slice state with no frontend/API layer, while README and later slice notes show both shipped.
+- Live Exa mode, S3/Postgres-backed runtime behavior, and deployed pilot environments remain unvalidated; the documented validated path is still local smoke mode.
 
 ## Docs freshness
-Mixed but workable. `README.md`, `docs/roadmap.md`, `docs/issue-tracker.md`, `docs/integration-boundaries.md`, and the 2026-03-22 implementation session notes reflect the current repo direction; the pilot architecture doc's current-state section and the pilot-alignment note lag behind the shipped API/frontend reality.
+Workable. `README.md`, `docs/local-validation.md`, `docs/roadmap.md`, `docs/issue-tracker.md`, `docs/integration-boundaries.md`, and `docs/pilot-architecture-decision.md` reflect the current smoke/local and persistence-in-progress posture; older March session notes remain historical and may describe pre-slice state.
 
 ## Setup friction
 Moderate. Python setup is straightforward, but full local work spans Python deps, optional `[api]` extras, a separate `frontend/` npm install and env file, and deliberate handling of smoke versus live mode with `EXA_API_KEY` only for bounded manual validation.
@@ -64,6 +64,7 @@ Moderate. Python setup is straightforward, but full local work spans Python deps
 
 ## Key files / commands
 - `README.md`
+- `docs/local-validation.md`
 - `docs/roadmap.md`
 - `docs/issue-tracker.md`
 - `docs/integration-boundaries.md`
@@ -83,7 +84,7 @@ Moderate. Python setup is straightforward, but full local work spans Python deps
 ## Wait until later
 - Any automatic promotion of generated heartbeat output into durable memory or strategy docs.
 - Scheduled or automatic live validation runs, dashboards, or cross-repo telemetry.
-- Scope beyond this scaffold into auth redesign, persistence implementation, async jobs, deployment, infra, or broader docs refactors.
+- Scope beyond this scaffold into auth redesign, persistence redesign, async jobs, deployment, infra, or broader docs refactors.
 
 ## Update policy
 `MEMORY.md` stays curated and human-reviewed. `memory/YYYY-MM-DD.md` stays append-only. `HEARTBEAT.md` and `heartbeat.json` are reproducible generated outputs and are never the durable source of truth.

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ Useful local URLs:
 
 | Method | Path | Request body | Description |
 | --- | --- | --- | --- |
-| `GET` | `/health` | — | Health check |
+| `GET` | `/health` | — | Health check with configured run/artifact backend labels |
 | `POST` | `/api/search` | `{"query": "...", "mode": "smoke"}` | Ranked search with evaluation |
 | `POST` | `/api/answer` | `{"query": "...", "mode": "smoke"}` | Cited-answer workflow |
 | `POST` | `/api/research` | `{"query": "...", "mode": "smoke"}` | Research report workflow |

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -34,7 +34,7 @@ Update it whenever issues are created, closed, re-scoped, or moved between miles
 | `#14 Add export/report outputs and demo-gallery documentation` | Task | `Phase 3 - Domain/Productization` | `type:task`, `area:docs`, `priority:p1`, `status:ready` | Closed | `#12, #7, #8, #13` | Phase 3 - Domain Coverage and Productization | `https://github.com/itprodirect/exai-insurance-intel/issues/14` | `docs/sessions/2026-04-11-issue-14-report-export.md` |
 | `#15 Epic: Documentation, governance, and repo operations` | Epic | `Phase 3 - Domain/Productization` | `type:epic`, `area:ops`, `priority:p0`, `status:ready` | Open | None | Phase 4 - Documentation, Governance, and Repo Operations | `https://github.com/itprodirect/exai-insurance-intel/issues/15` | `docs/sessions/2026-03-10-roadmap-baseline.md` |
 | `#16 Extend CI/security hardening and document integration follow-ons` | Task | `Phase 3 - Domain/Productization` | `type:task`, `area:ops`, `priority:p1`, `status:ready` | In progress | `#15, #14` | Phase 3 - Domain Coverage and Productization | `https://github.com/itprodirect/exai-insurance-intel/issues/16` | `docs/sessions/2026-03-21-payload-boundary-cleanup.md` |
-| `#17 Maintain roadmap, issue tracker, ADRs, and session notes` | Task | `Phase 3 - Domain/Productization` | `type:task`, `area:docs`, `priority:p0`, `status:ready` | In progress | `#15` | Phase 4 - Documentation, Governance, and Repo Operations | `https://github.com/itprodirect/exai-insurance-intel/issues/17` | `docs/sessions/2026-04-12-issue-17-docs-truth-sync.md` |
+| `#17 Maintain roadmap, issue tracker, ADRs, and session notes` | Task | `Phase 3 - Domain/Productization` | `type:task`, `area:docs`, `priority:p0`, `status:ready` | In progress | `#15` | Phase 4 - Documentation, Governance, and Repo Operations | `https://github.com/itprodirect/exai-insurance-intel/issues/17` | `docs/sessions/2026-04-28-issue-23-persistence-health-posture.md` |
 | `#18 Upgrade README with feature matrix, architecture diagram, and roadmap links` | Task | `Phase 3 - Domain/Productization` | `type:task`, `area:docs`, `priority:p1`, `status:ready` | Closed | `#15` | Phase 4 - Documentation, Governance, and Repo Operations | `https://github.com/itprodirect/exai-insurance-intel/issues/18` | `docs/sessions/2026-03-18-phase2-parallel-slices.md` |
 
 ## Phase 5 - Pilot Web Product
@@ -45,7 +45,7 @@ Update it whenever issues are created, closed, re-scoped, or moved between miles
 | `#20 Thin FastAPI wrapper over existing workflows` | Task | `Phase 5 - Pilot` | `type:task`, `area:api`, `priority:p0`, `status:done` | Done | `#19` | Phase 5 Level 1 | TBD | `docs/sessions/2026-03-22-api-wrapper.md` |
 | `#21 Frontend app shell (Next.js + Tailwind + shadcn/ui)` | Task | `Phase 5 - Pilot` | `type:task`, `area:frontend`, `priority:p0`, `status:done` | Done | `#19, #20` | Phase 5 Level 1 | TBD | `docs/sessions/2026-03-22-frontend-shell.md` |
 | `#22 Pilot auth + request/budget boundary controls` | Task | `Phase 5 - Pilot` | `type:task`, `area:auth`, `priority:p0`, `status:done` | Done | `#19, #20` | Phase 5 Level 1 | TBD | `docs/sessions/2026-04-11-issue-22-run-pagination-bounds.md` |
-| `#23 Persistence/state baseline (S3 artifacts + Postgres usage)` | Task | `Phase 5 - Pilot` | `type:task`, `area:infra`, `priority:p1`, `status:ready` | In progress | `#19, #20` | Phase 5 Level 1 | TBD | `docs/sessions/2026-04-12-issue-17-docs-truth-sync.md` |
+| `#23 Persistence/state baseline (S3 artifacts + Postgres usage)` | Task | `Phase 5 - Pilot` | `type:task`, `area:infra`, `priority:p1`, `status:ready` | In progress | `#19, #20` | Phase 5 Level 1 | TBD | `docs/sessions/2026-04-28-issue-23-persistence-health-posture.md` |
 
 ### Next Coding Slices (Sequenced)
 
@@ -54,7 +54,7 @@ These are the immediate next implementation tasks, in recommended execution orde
 1. ~~**Slice 1: Thin API wrapper** (`#20`)~~ — Done. FastAPI app at `src/exa_demo/api.py` with 5 POST endpoints + health. 9 smoke-mode tests.
 2. ~~**Slice 2: Frontend app shell** (`#21`)~~ — Done. Next.js app in `frontend/` with search, answer, research panels. Server-side proxy to backend.
 3. ~~**Slice 3: Pilot auth + boundary controls** (`#22`)~~ — Done. Owner-or-ops record access, multi-user rate-limit isolation, saved-query input bounds, and run-pagination bounds are shipped.
-4. **Slice 4: Persistence baseline** (`#23`) - In progress. S3 artifact-location persistence and Postgres repository/factory coverage are merged; remaining work should continue tightening the pilot persistence baseline without widening into deployment or infra rollout.
+4. **Slice 4: Persistence baseline** (`#23`) - In progress. S3 artifact-location persistence, Postgres repository/factory coverage, backend factory logging, optional pilot dependency extras, and health backend labels are present; remaining work should continue tightening the pilot persistence baseline without widening into deployment or infra rollout.
 
 Each slice should be one focused agent session. See [agent-execution-defaults.md](./agent-execution-defaults.md) for session rules.
 

--- a/docs/local-validation.md
+++ b/docs/local-validation.md
@@ -81,6 +81,8 @@ Check:
 - `http://127.0.0.1:8000/health`
 - `http://127.0.0.1:8000/docs`
 
+The health response should include `status`, `run_store`, and `artifact_store` so local checks can confirm which persistence backends the API process selected.
+
 6. Start the frontend in a second terminal.
 
 ```powershell

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -138,7 +138,7 @@ Current local validation remains smoke/local only. Live Exa mode and S3/Postgres
 | Thin API wrapper | Expose existing workflows as FastAPI endpoints | Decouples frontend from Python CLI; enables web product path | `Done` | Phase 1-4 baseline | FastAPI app serves search, answer, research, find-similar, structured-search over HTTP with JSON responses | TBD |
 | Frontend app shell | Next.js + TypeScript + Tailwind + shadcn/ui scaffold with App Router | Establishes the frontend stack and deploy target | `Done` | Thin API wrapper | App shell renders, routes work, can call API endpoints | TBD |
 | Pilot auth + request boundary | Internal-only auth, request validation, rate limiting, budget guardrails, request logging | Prevents uncontrolled usage before the product is hardened | `Done` | Thin API wrapper | Only authenticated internal users can make requests; spend is bounded and logged | TBD |
-| Persistence baseline | Artifacts in S3, relational state/usage in Postgres, existing SQLite cache kept for local dev | Moves beyond local-only SQLite for pilot durability | `In progress` | Thin API wrapper | Target state: pilot runs persist artifacts to S3 and track usage in Postgres after explicit end-to-end validation | TBD |
+| Persistence baseline | Artifacts in S3, relational state/usage in Postgres, existing SQLite cache kept for local dev | Moves beyond local-only SQLite for pilot durability | `In progress` | Thin API wrapper | Target state: pilot runs persist artifacts to S3 and track usage in Postgres after explicit end-to-end validation; current API health output reports the selected run/artifact backends | TBD |
 
 ### Level 2 - Limited External Beta
 

--- a/docs/sessions/2026-04-28-issue-23-persistence-health-posture.md
+++ b/docs/sessions/2026-04-28-issue-23-persistence-health-posture.md
@@ -1,0 +1,60 @@
+# Session: Issue 23 persistence health posture
+
+- Date: 2026-04-28
+- Participants: Codex, user
+- Related roadmap items: `#17`, `#23`
+- Related ADRs: none
+
+## Context
+
+Close the session after a narrow Phase 5 persistence-baseline slice that makes the API process report which run and artifact persistence backends it selected.
+
+## Repo Facts Observed
+
+- The worktree was already on `codex/issue-17-local-smoke-doc-sync`.
+- `src/exa_demo/api.py` now returns `run_store` and `artifact_store` from `/health` and `/api/health`.
+- The health endpoint remains unauthenticated when bearer auth is enabled.
+- `src/exa_demo/persistence.py` now logs selected local, Postgres, local artifact, and S3 artifact factory backends.
+- `.env.example` now documents optional pilot persistence env vars.
+- `pyproject.toml` now exposes optional `postgres`, `s3`, and aggregate `pilot` extras.
+- The current change remains a local/tested posture slice; it does not deploy or live-validate S3/Postgres infrastructure.
+
+## Decisions Made
+
+- Keep this as a narrow `#23` persistence-baseline posture slice.
+- Keep `/health` open and use it to expose backend labels only, not secrets or connection strings.
+- Record the final closeout in session notes, memory, tracker pointers, and regenerated heartbeat sidecars.
+
+## Issues Opened or Updated
+
+- `#17 Maintain roadmap, issue tracker, ADRs, and session notes` - advanced with final closeout docs.
+- Local tracker item `#23` - advanced with API health backend labels, factory logging, optional pilot dependency extras, and env documentation.
+
+## Docs Touched
+
+- `README.md`
+- `docs/local-validation.md`
+- `docs/issue-tracker.md`
+- `docs/roadmap.md`
+- `MEMORY.md`
+- `memory/2026-04-28.md`
+- `docs/sessions/2026-04-28-issue-23-persistence-health-posture.md`
+- `HEARTBEAT.md`
+- `heartbeat.json`
+
+## Tests and Checks Run
+
+- `python -m ruff check src/exa_demo/api.py src/exa_demo/persistence.py tests/test_api.py tests/test_api_auth.py` -> passed
+- `python -m pytest -q tests/test_api.py tests/test_api_auth.py` -> passed (`31 passed`)
+- `python -m pytest -q tests/test_persistence.py` -> passed (`62 passed`)
+
+## Outcome
+
+- The API health response now reports the selected run and artifact backends while preserving unauthenticated health access.
+- Optional pilot persistence dependency groups and env knobs are documented for future pilot setup.
+- The final docs pass records that `#23` remains in progress and still needs explicit S3/Postgres-backed end-to-end validation before claiming pilot durability.
+
+## Next-Session Handoff
+
+- Continue `#23` with one more narrow persistence-baseline slice, preferably an integration seam that validates configured Postgres/S3 behavior without broad deployment work.
+- Keep deployment, migrations, and auth redesign out of scope unless explicitly requested.

--- a/heartbeat.json
+++ b/heartbeat.json
@@ -1,9 +1,9 @@
 {
   "repo": "exai-insurance-intel",
-  "generated_at": "2026-04-12T02:14:21.887065+00:00",
+  "generated_at": "2026-04-28T05:21:10.487271+00:00",
   "purpose": "Exa-powered insurance intelligence toolkit for CAT-loss, claims, expert, contractor, and market/regulatory research workflows.",
   "strategic_role": "Workflow engine plus controlled pilot web-product base for internal insurance-intelligence validation.",
-  "current_milestone": "Phase 5 Level 1 is partially complete: the thin FastAPI wrapper, frontend shell, and pilot auth/request-boundary hardening are shipped, and the persistence baseline is now the active next bounded slice.",
+  "current_milestone": "Phase 5 Level 1 is partially complete: the thin FastAPI wrapper, frontend shell, and pilot auth/request-boundary hardening are shipped, and the persistence baseline is in progress with additive S3/Postgres adapters plus API health self-reporting for selected persistence backends.",
   "durable_decisions": [
     "Markdown docs under `docs/` remain the canonical backlog, architecture, ADR, and session-history surface for this repo.",
     "Existing CLI commands, artifact contracts, and smoke-first workflow expectations are stable and should be extended additively rather than rewritten.",
@@ -13,11 +13,11 @@
   ],
   "operating_posture": "Active Python workflow repo with package code in `src/exa_demo/`, a thin FastAPI app in the same package, and a Next.js frontend in `frontend/`. SQLite cache, budget controls, benchmark fixtures, exported artifacts, and smoke/live execution modes are already in place. Manual live validation is script-backed, but the inspected docs only verify smoke validation runs so far.",
   "top_blockers": [
-    "Phase 5 Level 1 is not complete because the persistence baseline is still missing; local SQLite is present, but the planned S3/Postgres pilot path is not yet implemented.",
+    "Phase 5 Level 1 is not complete because the persistence baseline still lacks end-to-end S3/Postgres-backed pilot validation and deployment posture; local defaults, pilot adapters, and backend self-reporting are present.",
     "GitHub issue numbering has drifted from the local Phase 5 roadmap IDs, so the tracker still has `TBD` GitHub URLs for those items until dedicated issues are created.",
-    "Docs freshness is mixed because `docs/pilot-architecture-decision.md` and `docs/sessions/2026-03-22-pilot-alignment.md` still describe a pre-slice state with no frontend/API layer, while README and later slice notes show both shipped."
+    "Live Exa mode, S3/Postgres-backed runtime behavior, and deployed pilot environments remain unvalidated; the documented validated path is still local smoke mode."
   ],
-  "docs_freshness": "Mixed but workable. `README.md`, `docs/roadmap.md`, `docs/issue-tracker.md`, `docs/integration-boundaries.md`, and the 2026-03-22 implementation session notes reflect the current repo direction; the pilot architecture doc's current-state section and the pilot-alignment note lag behind the shipped API/frontend reality.",
+  "docs_freshness": "Workable. `README.md`, `docs/local-validation.md`, `docs/roadmap.md`, `docs/issue-tracker.md`, `docs/integration-boundaries.md`, and `docs/pilot-architecture-decision.md` reflect the current smoke/local and persistence-in-progress posture; older March session notes remain historical and may describe pre-slice state.",
   "setup_friction": "Moderate. Python setup is straightforward, but full local work spans Python deps, optional `[api]` extras, a separate `frontend/` npm install and env file, and deliberate handling of smoke versus live mode with `EXA_API_KEY` only for bounded manual validation.",
   "validation_path": [
     "`python -m ruff check .`",
@@ -28,6 +28,7 @@
   ],
   "key_files_commands": [
     "`README.md`",
+    "`docs/local-validation.md`",
     "`docs/roadmap.md`",
     "`docs/issue-tracker.md`",
     "`docs/integration-boundaries.md`",
@@ -47,35 +48,38 @@
   "wait_until_later": [
     "Any automatic promotion of generated heartbeat output into durable memory or strategy docs.",
     "Scheduled or automatic live validation runs, dashboards, or cross-repo telemetry.",
-    "Scope beyond this scaffold into auth redesign, persistence implementation, async jobs, deployment, infra, or broader docs refactors."
+    "Scope beyond this scaffold into auth redesign, persistence redesign, async jobs, deployment, infra, or broader docs refactors."
   ],
   "update_policy": "`MEMORY.md` stays curated and human-reviewed. `memory/YYYY-MM-DD.md` stays append-only. `HEARTBEAT.md` and `heartbeat.json` are reproducible generated outputs and are never the durable source of truth.",
   "last_session": {
-    "date": "2026-04-11e",
-    "objective": "Take a simple end-of-session docs slice by syncing the local Phase 5 tracker and durable memory to the merged work.",
+    "date": "2026-04-28",
+    "objective": "Close the session with a final docs pass after a narrow Phase 5 persistence-baseline posture slice.",
     "changes_made": [
-      "Inspected the local tracker, roadmap, heartbeat, and memory snapshot after the merged `#22` and first `#23` slices.",
-      "Marked the local Phase 5 `#22` tracker item as done and kept `#23` as the active next slice.",
-      "Updated the roadmap and `MEMORY.md` so they reflect that auth/request-boundary hardening is shipped and persistence is now the primary Phase 5 Level 1 blocker.",
-      "Documented the Phase 5 numbering drift: local tracker IDs `#19`-`#23` are roadmap/task IDs, while GitHub numbers `22` and `23` are already occupied by older merged PRs.",
-      "Added the session note and synced the tracker pointer for `#17`."
+      "Added API health response fields for the selected run and artifact persistence backends.",
+      "Kept `/health` and `/api/health` unauthenticated while expanding their response shape.",
+      "Added backend-selection logging for local/Postgres run repositories and local/S3 artifact stores.",
+      "Added optional `postgres`, `s3`, and aggregate `pilot` extras in `pyproject.toml`.",
+      "Documented optional pilot persistence env vars in `.env.example`.",
+      "Updated README/local-validation wording, tracker pointers, roadmap wording, durable memory, and the session log for the final closeout."
     ],
     "validation_run": [
-      "No code or test changes; docs-only sync."
+      "`python -m ruff check src/exa_demo/api.py src/exa_demo/persistence.py tests/test_api.py tests/test_api_auth.py` -> passed",
+      "`python -m pytest -q tests/test_api.py tests/test_api_auth.py` -> passed (`31 passed`)",
+      "`python -m pytest -q tests/test_persistence.py` -> passed (`62 passed`)"
     ],
     "open_issues": [
-      "Dedicated GitHub issues still need to be created for the local Phase 5 tracker items if the repo wants live issue links instead of `TBD`.",
-      "`docs/pilot-architecture-decision.md` and the earlier pilot-alignment note still lag the shipped API/frontend reality."
+      "Local Phase 5 `#23` remains in progress; S3/Postgres-backed pilot behavior still needs explicit end-to-end validation before durability is claimed.",
+      "Dedicated GitHub issues still need to be created for the local Phase 5 tracker items if the repo wants live issue links instead of `TBD`."
     ],
     "decisions_proposed": [
-      "Treat the local Phase 5 tracker IDs as internal roadmap IDs until dedicated GitHub issues are created, instead of linking them to unrelated GitHub numbers.",
-      "Keep the next coding work on `#23` persistence slices rather than reopening the completed `#22` boundary track."
+      "Keep backend labels on health responses limited to coarse backend names (`local`, `postgres`, `s3`) and avoid exposing connection details.",
+      "Continue persistence-baseline work in thin slices rather than bundling deployment, migrations, or auth redesign into `#23`."
     ],
     "next_thin_slice": [
-      "Continue `#23` with another small persistence-baseline seam, or end the session here if you want to wind down cleanly."
+      "Add one focused `#23` validation seam for configured Postgres/S3 behavior, or stop here and merge this posture slice first."
     ]
   },
   "next_thin_slice": [
-    "Continue `#23` with another small persistence-baseline seam, or end the session here if you want to wind down cleanly."
+    "Add one focused `#23` validation seam for configured Postgres/S3 behavior, or stop here and merge this posture slice first."
   ]
 }

--- a/memory/2026-04-28.md
+++ b/memory/2026-04-28.md
@@ -1,0 +1,34 @@
+# Session Memory
+
+## Objective
+
+Close the session with a final docs pass after a narrow Phase 5 persistence-baseline posture slice.
+
+## Changes made
+
+- Added API health response fields for the selected run and artifact persistence backends.
+- Kept `/health` and `/api/health` unauthenticated while expanding their response shape.
+- Added backend-selection logging for local/Postgres run repositories and local/S3 artifact stores.
+- Added optional `postgres`, `s3`, and aggregate `pilot` extras in `pyproject.toml`.
+- Documented optional pilot persistence env vars in `.env.example`.
+- Updated README/local-validation wording, tracker pointers, roadmap wording, durable memory, and the session log for the final closeout.
+
+## Validation run
+
+- `python -m ruff check src/exa_demo/api.py src/exa_demo/persistence.py tests/test_api.py tests/test_api_auth.py` -> passed
+- `python -m pytest -q tests/test_api.py tests/test_api_auth.py` -> passed (`31 passed`)
+- `python -m pytest -q tests/test_persistence.py` -> passed (`62 passed`)
+
+## Open issues
+
+- Local Phase 5 `#23` remains in progress; S3/Postgres-backed pilot behavior still needs explicit end-to-end validation before durability is claimed.
+- Dedicated GitHub issues still need to be created for the local Phase 5 tracker items if the repo wants live issue links instead of `TBD`.
+
+## Decisions proposed
+
+- Keep backend labels on health responses limited to coarse backend names (`local`, `postgres`, `s3`) and avoid exposing connection details.
+- Continue persistence-baseline work in thin slices rather than bundling deployment, migrations, or auth redesign into `#23`.
+
+## Next thin slice
+
+- Add one focused `#23` validation seam for configured Postgres/S3 behavior, or stop here and merge this posture slice first.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,15 @@ api = [
   "fastapi>=0.115",
   "uvicorn[standard]>=0.34",
 ]
+postgres = [
+  "psycopg2-binary>=2.9",
+]
+s3 = [
+  "boto3>=1.35",
+]
+pilot = [
+  "exai-insurance-intel[api,postgres,s3]",
+]
 dev = [
   "httpx>=0.27",
   "nbclient==0.10.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
   "requests==2.33.0",
-  "python-dotenv==1.0.1",
+  "python-dotenv==1.2.2",
   "pandas==2.2.3",
   "tabulate==0.9.0",
 ]
@@ -34,7 +34,7 @@ dev = [
   "nbclient==0.10.2",
   "nbformat==5.10.4",
   "pre-commit==4.1.0",
-  "pytest==8.3.5",
+  "pytest==9.0.3",
   "ruff==0.9.10",
   "exai-insurance-intel[api]",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 requests==2.33.0
-python-dotenv==1.0.1
+python-dotenv==1.2.2
 pandas==2.2.3
 tabulate==0.9.0
 nbclient==0.10.2
 nbformat==5.10.4
-pytest==8.3.5
+pytest==9.0.3

--- a/src/exa_demo/api.py
+++ b/src/exa_demo/api.py
@@ -48,7 +48,11 @@ from .endpoint_workflows import (
 )
 from .jobs import submit_job
 from .persistence import (
+    LocalArtifactStore,
+    LocalRunRepository,
     SavedQuery,
+    S3ArtifactStore,
+    PostgresRunRepository,
     create_artifact_store,
     create_run_repository,
     persist_workflow_run,
@@ -125,6 +129,8 @@ class StructuredSearchRequest(BaseModel):
 
 class HealthResponse(BaseModel):
     status: str
+    run_store: str
+    artifact_store: str
 
 
 class SearchResponse(BaseModel):
@@ -347,10 +353,30 @@ def _persist(
 # ---------------------------------------------------------------------------
 
 
+def _run_store_label() -> str:
+    if isinstance(run_repo, PostgresRunRepository):
+        return "postgres"
+    if isinstance(run_repo, LocalRunRepository):
+        return "local"
+    return "local"
+
+
+def _artifact_store_label() -> str:
+    if isinstance(artifact_store, S3ArtifactStore):
+        return "s3"
+    if isinstance(artifact_store, LocalArtifactStore):
+        return "local"
+    return "local"
+
+
 @app.get("/health", response_model=HealthResponse)
 @app.get("/api/health", response_model=HealthResponse, include_in_schema=False)
 def health() -> Dict[str, str]:
-    return {"status": "ok"}
+    return {
+        "status": "ok",
+        "run_store": _run_store_label(),
+        "artifact_store": _artifact_store_label(),
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/src/exa_demo/persistence.py
+++ b/src/exa_demo/persistence.py
@@ -917,8 +917,10 @@ def create_artifact_store() -> ArtifactStore:
                 "PILOT_S3_BUCKET is required when PILOT_ARTIFACT_STORE=s3"
             )
         prefix = os.environ.get("PILOT_S3_PREFIX", "artifacts/").strip()
+        logger.info("Using s3 artifact store backend")
         return S3ArtifactStore(bucket=bucket, prefix=prefix)
 
+    logger.info("Using local artifact store backend")
     return LocalArtifactStore()
 
 
@@ -932,9 +934,11 @@ def create_run_repository() -> RunRepository:
             raise RuntimeError(
                 "PILOT_POSTGRES_URL is required when PILOT_RUN_STORE=postgres"
             )
+        logger.info("Using postgres run repository backend")
         return PostgresRunRepository(dsn=dsn)
 
     db_path = os.environ.get("PILOT_RUN_STORE_PATH", "pilot_runs.sqlite").strip()
+    logger.info("Using local run repository backend")
     return LocalRunRepository(db_path=db_path)
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -46,7 +46,11 @@ def _make_prepare_context_with_sqlite(sqlite_path):
 def test_health(client):
     resp = client.get("/health")
     assert resp.status_code == 200
-    assert resp.json() == {"status": "ok"}
+    assert resp.json() == {
+        "status": "ok",
+        "run_store": "local",
+        "artifact_store": "local",
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -81,13 +81,22 @@ def test_health_no_auth_required(auth_client):
     """Health endpoint must remain open even when auth is enabled."""
     resp = auth_client.get("/health")
     assert resp.status_code == 200
-    assert resp.json() == {"status": "ok"}
+    assert resp.json() == {
+        "status": "ok",
+        "run_store": "local",
+        "artifact_store": "local",
+    }
 
 
 def test_api_health_no_auth_required(auth_client):
     """The /api/health alias must also remain open."""
     resp = auth_client.get("/api/health")
     assert resp.status_code == 200
+    assert resp.json() == {
+        "status": "ok",
+        "run_store": "local",
+        "artifact_store": "local",
+    }
 
 
 def test_auth_missing_header(auth_client):


### PR DESCRIPTION
## Summary

- Adds `run_store` and `artifact_store` labels to `/health` and `/api/health` so local and pilot operators can see which persistence backends the API selected.
- Adds coarse backend-selection logging in the persistence factories.
- Documents optional pilot persistence env vars and dependency extras.
- Adds the final session closeout docs, memory entry, tracker updates, and regenerated heartbeat artifacts.

## Why

This advances the Phase 5 `#23` persistence baseline without widening into deployment, migrations, or auth redesign. The API can now report local vs pilot persistence posture using coarse labels while preserving unauthenticated health access and avoiding connection details.

## Impact

- Health responses now include `status`, `run_store`, and `artifact_store`.
- Existing health endpoints remain open when bearer auth is enabled.
- S3/Postgres-backed pilot behavior is still not claimed as end-to-end validated; docs keep that limitation explicit.

## Validation

- `python -m ruff check src/exa_demo/api.py src/exa_demo/persistence.py tests/test_api.py tests/test_api_auth.py`
- `python -m pytest -q tests/test_api.py tests/test_api_auth.py` (`31 passed`)
- `python -m pytest -q tests/test_persistence.py` (`62 passed`)