### PR TITLE
[codex] harden API request boundaries

### DIFF
--- a/src/exa_demo/api.py
+++ b/src/exa_demo/api.py
@@ -23,7 +23,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from .api_auth import (
     RequestLoggingMiddleware,
@@ -37,6 +37,7 @@ from .api_auth import (
     validate_mode,
     validate_pagination,
     validate_query,
+    validate_seed_url,
 )
 from .cli_runtime import resolve_runtime, runtime_metadata
 from .config import default_config, default_pricing
@@ -85,7 +86,11 @@ artifact_store = create_artifact_store()
 # ---------------------------------------------------------------------------
 
 
-class SearchRequest(BaseModel):
+class ApiRequestModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class SearchRequest(ApiRequestModel):
     query: str
     mode: str = Field(
         default="smoke",
@@ -98,23 +103,23 @@ class SearchRequest(BaseModel):
     num_results: int = Field(default=5, ge=1, le=100)
 
 
-class AnswerRequest(BaseModel):
+class AnswerRequest(ApiRequestModel):
     query: str
     mode: str = Field(default="smoke")
 
 
-class ResearchRequest(BaseModel):
+class ResearchRequest(ApiRequestModel):
     query: str
     mode: str = Field(default="smoke")
 
 
-class FindSimilarRequest(BaseModel):
+class FindSimilarRequest(ApiRequestModel):
     url: str
     mode: str = Field(default="smoke")
     num_results: int = Field(default=5, ge=1, le=100)
 
 
-class StructuredSearchRequest(BaseModel):
+class StructuredSearchRequest(ApiRequestModel):
     query: str
     output_schema: Dict[str, Any] = Field(
         description="JSON Schema for structured extraction",
@@ -245,7 +250,7 @@ class OpsSummaryResponse(BaseModel):
     by_mode: List[ModeBreakdown] = Field(default_factory=list)
 
 
-class SavedQueryRequest(BaseModel):
+class SavedQueryRequest(ApiRequestModel):
     workflow: str
     query: str
     label: Optional[str] = None
@@ -585,6 +590,7 @@ def api_get_research_job(job_id: str, request: Request) -> Dict[str, Any]:
 @api_router.post("/find-similar", response_model=FindSimilarResponse)
 def api_find_similar(req: FindSimilarRequest, request: Request) -> Dict[str, Any]:
     validate_mode(req.mode)
+    seed_url = validate_seed_url(req.url)
     clamped = clamp_num_results(req.num_results)
     overrides: Dict[str, Any] = {"num_results": clamped}
     config, pricing, runtime, meta = _prepare_context(req.mode, overrides)
@@ -594,7 +600,7 @@ def api_find_similar(req: FindSimilarRequest, request: Request) -> Dict[str, Any
     t0 = time.monotonic()
     try:
         payload = run_find_similar_workflow(
-            seed_url=req.url,
+            seed_url=seed_url,
             artifact_dir=ARTIFACT_DIR,
             config=config,
             pricing=pricing,
@@ -607,7 +613,7 @@ def api_find_similar(req: FindSimilarRequest, request: Request) -> Dict[str, Any
             mode=req.mode,
             request_id=rid,
             payload=payload,
-            query_preview=req.url,
+            query_preview=seed_url,
             started_at=started_at,
             duration_ms=duration_ms,
             user_id=uid,
@@ -620,7 +626,7 @@ def api_find_similar(req: FindSimilarRequest, request: Request) -> Dict[str, Any
             mode=req.mode,
             request_id=rid,
             payload={},
-            query_preview=req.url,
+            query_preview=seed_url,
             started_at=started_at,
             duration_ms=duration_ms,
             status="failed",

--- a/src/exa_demo/api_auth.py
+++ b/src/exa_demo/api_auth.py
@@ -23,6 +23,8 @@ import os
 import time
 import uuid
 from collections import defaultdict
+from urllib.parse import urlparse
+
 from fastapi import HTTPException, Request
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import Response
@@ -274,14 +276,42 @@ def validate_mode(mode: str) -> str:
 
 
 def validate_query(query: str) -> str:
-    """Raise 400 for queries that exceed pilot length limits."""
+    """Raise 400 for queries that are blank or exceed pilot length limits."""
     max_len = _pilot_max_query_length()
+    if not query.strip():
+        raise HTTPException(status_code=400, detail="Query must not be empty.")
     if len(query) > max_len:
         raise HTTPException(
             status_code=400,
             detail=f"Query too long ({len(query)} chars). Maximum: {max_len}.",
         )
     return query
+
+
+def validate_seed_url(url: str) -> str:
+    """Raise 400 for invalid find-similar seed URLs."""
+    candidate = url.strip()
+    max_len = _pilot_max_query_length()
+    if not candidate:
+        raise HTTPException(status_code=400, detail="URL must not be empty.")
+    if len(candidate) > max_len:
+        raise HTTPException(
+            status_code=400,
+            detail=f"URL too long ({len(candidate)} chars). Maximum: {max_len}.",
+        )
+    if any(char.isspace() for char in candidate):
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid URL. Use an absolute http(s) URL.",
+        )
+
+    parsed = urlparse(candidate)
+    if parsed.scheme.lower() not in {"http", "https"} or not parsed.netloc:
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid URL. Use an absolute http(s) URL.",
+        )
+    return candidate
 
 
 def clamp_num_results(num_results: int) -> int:

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -232,6 +232,14 @@ def test_query_too_long_rejected(open_client, monkeypatch):
     assert "Query too long" in resp.json()["detail"]
 
 
+def test_blank_query_rejected(open_client):
+    resp = open_client.post(
+        "/api/search", json={"query": "   ", "mode": "smoke"}
+    )
+    assert resp.status_code == 400
+    assert "Query must not be empty" in resp.json()["detail"]
+
+
 def test_num_results_clamped(open_client, monkeypatch):
     """Requesting more than PILOT_MAX_RESULTS should be silently clamped."""
     monkeypatch.setenv("PILOT_MAX_RESULTS", "3")
@@ -242,6 +250,32 @@ def test_num_results_clamped(open_client, monkeypatch):
     assert resp.status_code == 200
     data = resp.json()
     assert data["record"]["result_count"] == 3
+
+
+def test_unexpected_payload_fields_rejected(open_client):
+    resp = open_client.post(
+        "/api/search",
+        json={"query": "test", "mode": "smoke", "user_id": "ops"},
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.parametrize(
+    "seed_url",
+    [
+        "",
+        "not-a-url",
+        "ftp://example.com/file",
+        "https://example.com/raw space",
+    ],
+)
+def test_find_similar_invalid_seed_url_rejected(open_client, seed_url):
+    resp = open_client.post(
+        "/api/find-similar",
+        json={"url": seed_url, "mode": "smoke"},
+    )
+    assert resp.status_code == 400
+    assert "URL" in resp.json()["detail"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Reject unexpected fields on API request bodies instead of silently ignoring them.
- Reject blank query strings before workflow execution.
- Validate find-similar seed URLs as absolute http(s) URLs and persist/use the normalized seed URL.

## Why

The pilot API already had auth, owner, ops, rate-limit, and mode checks. This closes smaller payload-boundary gaps where malformed or over-broad request bodies could pass into workflow execution.

## Validation

- `python -m pytest tests\test_api_auth.py tests\test_api.py`
- `python -m pytest tests\test_users.py tests\test_jobs.py tests\test_persistence.py`
- `python -m ruff check src\exa_demo\api.py src\exa_demo\api_auth.py tests\test_api_auth.py`