### PR TITLE
[codex] Modernize Exa payload controls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
 
 [project.optional-dependencies]
 api = [
-  "fastapi>=0.115",
+  "fastapi>=0.115,<0.136.3",
   "uvicorn[standard]>=0.34",
 ]
 postgres = [

--- a/src/exa_demo/cli_parser.py
+++ b/src/exa_demo/cli_parser.py
@@ -6,6 +6,14 @@ from typing import Any, Callable, Dict, Mapping
 from .config import default_config
 from .ranked_workflows import LEGACY_DEFAULT_SUITE_ALIAS, benchmark_suite_choices
 
+FRESHNESS_MAX_AGE_HOURS = {
+    "default": None,
+    "cache-only": -1,
+    "daily": 24,
+    "near-real-time": 1,
+    "always-live": 0,
+}
+
 
 def build_parser(*, handlers: Mapping[str, Callable[..., int]]) -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
@@ -208,8 +216,7 @@ def apply_search_overrides(
         config["start_published_date"] = str(args.start_published_date).strip()
     if getattr(args, "end_published_date", None):
         config["end_published_date"] = str(args.end_published_date).strip()
-    if getattr(args, "livecrawl", None):
-        config["livecrawl"] = True
+    _apply_freshness_override(config, args)
     if hasattr(args, "use_text") and args.use_text:
         config["use_text"] = True
     if hasattr(args, "use_summary") and args.use_summary:
@@ -309,7 +316,22 @@ def _add_common_search_args(
         "--end-published-date",
         help="Optional upper bound for published date filtering (YYYY-MM-DD).",
     )
-    parser.add_argument("--livecrawl", action="store_true", help="Force live crawl for the request.")
+    parser.add_argument(
+        "--max-age-hours",
+        type=int,
+        help="Maximum cached content age in hours; 0 always livecrawls, -1 uses cache only.",
+    )
+    parser.add_argument(
+        "--freshness",
+        choices=list(FRESHNESS_MAX_AGE_HOURS),
+        default="default",
+        help="Named freshness policy for contents.maxAgeHours.",
+    )
+    parser.add_argument(
+        "--livecrawl",
+        action="store_true",
+        help="Deprecated alias for --max-age-hours 0.",
+    )
     parser.add_argument(
         "--search-cost-1-25",
         type=float,
@@ -360,6 +382,21 @@ def _apply_pricing_overrides(pricing: Dict[str, float], args: argparse.Namespace
         value = getattr(args, arg_name, None)
         if value is not None:
             pricing[key] = float(value)
+
+
+def _apply_freshness_override(config: Dict[str, Any], args: argparse.Namespace) -> None:
+    max_age_hours = getattr(args, "max_age_hours", None)
+    if max_age_hours is not None:
+        config["max_age_hours"] = int(max_age_hours)
+        return
+
+    freshness = getattr(args, "freshness", "default")
+    if freshness != "default":
+        config["max_age_hours"] = FRESHNESS_MAX_AGE_HOURS[freshness]
+        return
+
+    if getattr(args, "livecrawl", None):
+        config["max_age_hours"] = 0
 
 
 def _clean_string_list(values: list[Any]) -> list[str]:

--- a/src/exa_demo/client.py
+++ b/src/exa_demo/client.py
@@ -21,6 +21,7 @@ from .client_smoke import (
     mock_exa_response,
     mock_exa_structured_search_response,
 )
+from .config import DEFAULT_HIGHLIGHT_MAX_CHARACTERS
 from .cost_model import estimate_cost_from_pricing
 from .resilience import CircuitBreaker
 from .safety import redact_response
@@ -371,14 +372,21 @@ def _resolve_exa_endpoint(base_url: str, *, endpoint_name: str) -> str:
 
 def _find_similar_cost_payload(payload: Mapping[str, Any]) -> Dict[str, Any]:
     cost_payload: Dict[str, Any] = {"type": "auto"}
+    request_contents = (
+        payload.get("contents")
+        if isinstance(payload.get("contents"), Mapping)
+        else {}
+    )
     contents: Dict[str, Any] = {}
-    if payload.get("text") is not False:
+    text = request_contents.get("text", payload.get("text"))
+    if text is not False:
         contents["text"] = True
-    if payload.get("highlights") is not None and payload.get("highlights") is not False:
+    highlights = request_contents.get("highlights", payload.get("highlights"))
+    if highlights is not None and highlights is not False:
         contents["highlights"] = (
-            payload.get("highlights")
-            if isinstance(payload.get("highlights"), Mapping)
-            else {"highlightsPerUrl": 1, "numSentences": 2}
+            highlights
+            if isinstance(highlights, Mapping)
+            else {"maxCharacters": DEFAULT_HIGHLIGHT_MAX_CHARACTERS}
         )
     if contents:
         cost_payload["contents"] = contents

--- a/src/exa_demo/client_payloads.py
+++ b/src/exa_demo/client_payloads.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any, Dict, Mapping, Optional, Sequence
 
+from .config import DEFAULT_HIGHLIGHT_MAX_CHARACTERS
+
 
 def build_exa_payload(
     query: str,
@@ -28,21 +30,18 @@ def build_exa_payload(
         payload["additionalQueries"] = additional_queries
     _assign_text_field(payload, "startPublishedDate", config.get("start_published_date"))
     _assign_text_field(payload, "endPublishedDate", config.get("end_published_date"))
-    if config.get("livecrawl"):
-        payload["livecrawl"] = True
 
     contents: Dict[str, Any] = {}
     if config["use_text"]:
         contents["text"] = True
     if config["use_highlights"]:
-        contents["highlights"] = {
-            "highlightsPerUrl": config["highlights_per_url"],
-            "numSentences": config["highlight_num_sentences"],
-        }
+        contents["highlights"] = _highlight_options(config)
     if config["use_summary"]:
         contents["summary"] = {
             "query": "Summarize the person's professional background and insurance/CAT relevance."
         }
+    _assign_int_field(contents, "maxAgeHours", config.get("max_age_hours"))
+    _assign_int_field(contents, "livecrawlTimeout", config.get("livecrawl_timeout"))
 
     if contents:
         payload["contents"] = contents
@@ -114,14 +113,19 @@ def build_find_similar_payload(
     _assign_text_field(payload, "endPublishedDate", end_published_date)
     if exclude_source_domain is not None:
         payload["excludeSourceDomain"] = bool(exclude_source_domain)
-    if context is not None:
-        payload["context"] = context
 
+    contents: Dict[str, Any] = {}
     resolved_text = True if text is None else text
     if resolved_text is not None:
-        payload["text"] = resolved_text
+        contents["text"] = resolved_text
     if highlights is not None:
-        payload["highlights"] = highlights
+        contents["highlights"] = _normalize_highlights(highlights, config)
+    if context is not None:
+        contents["context"] = context
+    _assign_int_field(contents, "maxAgeHours", config.get("max_age_hours"))
+    _assign_int_field(contents, "livecrawlTimeout", config.get("livecrawl_timeout"))
+    if contents:
+        payload["contents"] = contents
 
     return payload
 
@@ -143,3 +147,43 @@ def _assign_text_field(payload: Dict[str, Any], field_name: str, value: Any) -> 
     text = str(value).strip()
     if text:
         payload[field_name] = text
+
+
+def _assign_int_field(payload: Dict[str, Any], field_name: str, value: Any) -> None:
+    if value is None:
+        return
+    if isinstance(value, str) and not value.strip():
+        return
+    payload[field_name] = int(value)
+
+
+def _highlight_options(config: Mapping[str, Any]) -> Dict[str, int]:
+    return {
+        "maxCharacters": int(
+            config.get("highlight_max_characters") or DEFAULT_HIGHLIGHT_MAX_CHARACTERS
+        )
+    }
+
+
+def _normalize_highlights(highlights: Any, config: Mapping[str, Any]) -> Any:
+    if highlights is True:
+        return _highlight_options(config)
+    if not isinstance(highlights, Mapping):
+        return highlights
+
+    if "maxCharacters" in highlights:
+        value = highlights["maxCharacters"]
+    elif "max_characters" in highlights:
+        value = highlights["max_characters"]
+    elif "numSentences" in highlights:
+        value = int(highlights["numSentences"]) * 1333
+    else:
+        value = config.get("highlight_max_characters") or DEFAULT_HIGHLIGHT_MAX_CHARACTERS
+
+    normalized = {
+        str(key): item
+        for key, item in highlights.items()
+        if str(key) not in {"highlightsPerUrl", "numSentences", "max_characters"}
+    }
+    normalized["maxCharacters"] = int(value)
+    return normalized

--- a/src/exa_demo/client_smoke.py
+++ b/src/exa_demo/client_smoke.py
@@ -60,12 +60,15 @@ def mock_exa_find_similar_response(payload: Mapping[str, Any]) -> Dict[str, Any]
     url = str(payload.get("url") or "")
     slug = sha256_hex(url)[:8]
     num_results = int(payload.get("numResults") or 5)
-    wants_text = payload.get("text") is not False
+    contents = payload.get("contents") if isinstance(payload.get("contents"), Mapping) else {}
+    wants_text = contents.get("text", payload.get("text")) is not False
+    highlights = contents.get("highlights", payload.get("highlights"))
     wants_highlights = (
-        payload.get("highlights") is not None and payload.get("highlights") is not False
+        highlights is not None and highlights is not False
     )
+    context = contents.get("context", payload.get("context"))
     wants_context = (
-        payload.get("context") is not None and payload.get("context") is not False
+        context is not None and context is not False
     )
 
     source_domain = _domain_from_url(url)

--- a/src/exa_demo/config.py
+++ b/src/exa_demo/config.py
@@ -7,6 +7,8 @@ from datetime import datetime, timezone
 from typing import Any, Dict, Mapping
 
 
+DEFAULT_HIGHLIGHT_MAX_CHARACTERS = 2666
+
 DEFAULT_CONFIG: Dict[str, Any] = {
     "exa_endpoint": "https://api.exa.ai/search",
     "search_type": "auto",
@@ -15,15 +17,15 @@ DEFAULT_CONFIG: Dict[str, Any] = {
     "user_location": "US",
     "use_text": False,
     "use_highlights": True,
-    "highlights_per_url": 1,
-    "highlight_num_sentences": 2,
+    "highlight_max_characters": DEFAULT_HIGHLIGHT_MAX_CHARACTERS,
     "use_summary": False,
     "include_domains": [],
     "exclude_domains": [],
     "additional_queries": [],
     "start_published_date": None,
     "end_published_date": None,
-    "livecrawl": False,
+    "max_age_hours": None,
+    "livecrawl_timeout": None,
     "moderation": True,
     "redact_emails_phones": True,
     "budget_cap_usd": 7.50,

--- a/src/exa_demo/cost_model.py
+++ b/src/exa_demo/cost_model.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import math
 from typing import Any, Dict, Iterable, Mapping
 
+from .config import DEFAULT_HIGHLIGHT_MAX_CHARACTERS
+
 
 def estimate_cost_from_pricing(
     payload: Mapping[str, Any],
@@ -42,8 +44,10 @@ def estimate_unit_cost_for_config(
         contents["text"] = True
     if config.get("use_highlights"):
         contents["highlights"] = {
-            "highlightsPerUrl": int(config["highlights_per_url"]),
-            "numSentences": int(config["highlight_num_sentences"]),
+            "maxCharacters": int(
+                config.get("highlight_max_characters")
+                or DEFAULT_HIGHLIGHT_MAX_CHARACTERS
+            ),
         }
     if config.get("use_summary"):
         contents["summary"] = {

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -11,10 +11,10 @@ def test_request_hash_is_deterministic_across_key_order() -> None:
     payload_a = {
         "query": "forensic engineer",
         "numResults": 5,
-        "contents": {"highlights": {"numSentences": 2, "highlightsPerUrl": 1}},
+        "contents": {"highlights": {"maxCharacters": 2666}},
     }
     payload_b = {
-        "contents": {"highlights": {"highlightsPerUrl": 1, "numSentences": 2}},
+        "contents": {"highlights": {"maxCharacters": 2666}},
         "numResults": 5,
         "query": "forensic engineer",
     }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,19 @@ from exa_demo.cache import SqliteCacheStore
 from exa_demo.cli import _apply_search_overrides, build_parser, main
 
 
+DEPRECATED_REQUEST_FIELDS = {'livecrawl', 'highlightsPerUrl', 'numSentences'}
+
+
+def assert_no_deprecated_request_fields(value) -> None:
+    if isinstance(value, dict):
+        assert DEPRECATED_REQUEST_FIELDS.isdisjoint(value)
+        for item in value.values():
+            assert_no_deprecated_request_fields(item)
+    elif isinstance(value, list):
+        for item in value:
+            assert_no_deprecated_request_fields(item)
+
+
 def test_search_command_smoke_emits_json_and_artifacts(tmp_path, capsys) -> None:
     sqlite_path = tmp_path / 'cache.sqlite'
     artifact_dir = tmp_path / 'artifacts'
@@ -33,6 +46,8 @@ def test_search_command_smoke_emits_json_and_artifacts(tmp_path, capsys) -> None
     assert output['run_id'] == 'cli-search'
     assert output['record']['result_count'] == 5
     assert 'taxonomy' in output
+    assert output['record']['request_payload']['contents']['highlights'] == {'maxCharacters': 2666}
+    assert_no_deprecated_request_fields(output['record']['request_payload'])
     assert (artifact_dir / 'cli-search' / 'summary.json').exists()
 
 
@@ -65,6 +80,9 @@ def test_eval_command_smoke_writes_artifacts(tmp_path, capsys) -> None:
     summary_payload = json.loads((artifact_dir / 'cli-eval' / 'summary.json').read_text(encoding='utf-8'))
     assert summary_payload['extra']['run_context']['query_suite'] == 'all'
     assert summary_payload['extra']['runtime']['execution_mode'] == 'smoke'
+    query_payload = json.loads((artifact_dir / 'cli-eval' / 'queries.jsonl').read_text(encoding='utf-8').splitlines()[0])
+    assert query_payload['request_payload']['contents']['highlights'] == {'maxCharacters': 2666}
+    assert_no_deprecated_request_fields(query_payload['request_payload'])
     assert (artifact_dir / 'cli-eval' / 'queries.jsonl').exists()
     assert (artifact_dir / 'cli-eval' / 'results.jsonl').exists()
     assert (artifact_dir / 'cli-eval' / 'results.csv').exists()
@@ -268,8 +286,27 @@ def test_search_parser_accepts_additive_deep_controls() -> None:
     assert args.start_published_date == '2026-01-01'
     assert args.end_published_date == '2026-03-01'
     assert args.livecrawl is True
+    assert args.freshness == 'default'
+    assert args.max_age_hours is None
     assert args.deep_search_cost_1_25 == 0.012
     assert args.deep_reasoning_search_cost_1_25 == 0.015
+
+
+def test_search_parser_accepts_freshness_controls() -> None:
+    parser = build_parser()
+    args = parser.parse_args(
+        [
+            'search',
+            'forensic engineer insurance expert witness',
+            '--freshness',
+            'near-real-time',
+            '--max-age-hours',
+            '6',
+        ]
+    )
+
+    assert args.freshness == 'near-real-time'
+    assert args.max_age_hours == 6
 
 
 def test_structured_search_parser_accepts_schema_file() -> None:
@@ -354,12 +391,64 @@ def test_apply_search_overrides_maps_additive_controls_and_pricing() -> None:
     ]
     assert config['start_published_date'] == '2026-01-01'
     assert config['end_published_date'] == '2026-03-01'
-    assert config['livecrawl'] is True
+    assert config['max_age_hours'] == 0
     assert pricing['search_1_25'] == 0.006
     assert pricing['deep_search_1_25'] == 0.012
     assert pricing['deep_search_26_100'] == 0.03
     assert pricing['deep_reasoning_search_1_25'] == 0.015
     assert pricing['deep_reasoning_search_26_100'] == 0.04
+
+
+@pytest.mark.parametrize(
+    ('freshness', 'expected_max_age_hours'),
+    [
+        ('default', None),
+        ('cache-only', -1),
+        ('daily', 24),
+        ('near-real-time', 1),
+        ('always-live', 0),
+    ],
+)
+def test_apply_search_overrides_maps_freshness_choices(
+    freshness: str, expected_max_age_hours: int | None
+) -> None:
+    from exa_demo.config import default_config, default_pricing
+
+    config = default_config()
+    pricing = default_pricing()
+    args = build_parser().parse_args(
+        [
+            'search',
+            'forensic engineer insurance expert witness',
+            '--freshness',
+            freshness,
+        ]
+    )
+
+    _apply_search_overrides(config, pricing, args)
+
+    assert config['max_age_hours'] == expected_max_age_hours
+
+
+def test_apply_search_overrides_prefers_explicit_max_age_hours() -> None:
+    from exa_demo.config import default_config, default_pricing
+
+    pricing = default_pricing()
+    config = default_config()
+    args = build_parser().parse_args(
+        [
+            'search',
+            'forensic engineer insurance expert witness',
+            '--freshness',
+            'near-real-time',
+            '--max-age-hours',
+            '6',
+        ]
+    )
+
+    _apply_search_overrides(config, pricing, args)
+
+    assert config['max_age_hours'] == 6
 
 
 def test_eval_parser_accepts_named_benchmark_suite() -> None:
@@ -582,6 +671,8 @@ def test_structured_search_command_smoke_emits_json_and_artifact(tmp_path, capsy
     structured_payload = json.loads((artifact_dir / 'structured-run' / 'structured_output.json').read_text(encoding='utf-8'))
     assert structured_payload['structured_output']['record_count'] == 1
     assert structured_payload['structured_output_keys'] == ['field_names', 'query', 'record_count', 'records', 'schema_title']
+    assert structured_payload['request_payload']['contents']['highlights'] == {'maxCharacters': 2666}
+    assert_no_deprecated_request_fields(structured_payload['request_payload'])
 
 
 def test_structured_search_command_live_requires_api_key(tmp_path, monkeypatch) -> None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -39,6 +39,19 @@ class FakeCacheStore:
         return result, False
 
 
+DEPRECATED_REQUEST_FIELDS = {"livecrawl", "highlightsPerUrl", "numSentences"}
+
+
+def assert_no_deprecated_request_fields(value) -> None:
+    if isinstance(value, dict):
+        assert DEPRECATED_REQUEST_FIELDS.isdisjoint(value)
+        for item in value.values():
+            assert_no_deprecated_request_fields(item)
+    elif isinstance(value, list):
+        for item in value:
+            assert_no_deprecated_request_fields(item)
+
+
 def test_build_exa_payload_includes_additive_deep_search_fields() -> None:
     config = default_config()
     config.update(
@@ -50,7 +63,7 @@ def test_build_exa_payload_includes_additive_deep_search_fields() -> None:
             ],
             "start_published_date": "2026-01-01",
             "end_published_date": "2026-03-01",
-            "livecrawl": True,
+            "max_age_hours": 0,
         }
     )
 
@@ -64,7 +77,9 @@ def test_build_exa_payload_includes_additive_deep_search_fields() -> None:
     ]
     assert payload["startPublishedDate"] == "2026-01-01"
     assert payload["endPublishedDate"] == "2026-03-01"
-    assert payload["livecrawl"] is True
+    assert payload["contents"]["maxAgeHours"] == 0
+    assert payload["contents"]["highlights"] == {"maxCharacters": 2666}
+    assert_no_deprecated_request_fields(payload)
     assert "results" not in payload
 
 
@@ -77,6 +92,9 @@ def test_build_exa_payload_leaves_additive_fields_out_by_default() -> None:
     assert "startPublishedDate" not in payload
     assert "endPublishedDate" not in payload
     assert "livecrawl" not in payload
+    assert "maxAgeHours" not in payload["contents"]
+    assert payload["contents"]["highlights"] == {"maxCharacters": 2666}
+    assert_no_deprecated_request_fields(payload)
 
 
 def test_mock_exa_response_preserves_search_result_shape_with_additive_controls() -> None:
@@ -87,7 +105,7 @@ def test_mock_exa_response_preserves_search_result_shape_with_additive_controls(
             "additional_queries": ["licensed public adjuster Florida"],
             "start_published_date": "2026-01-01",
             "end_published_date": "2026-03-01",
-            "livecrawl": True,
+            "max_age_hours": 0,
         },
     )
 
@@ -133,9 +151,10 @@ def test_build_find_similar_payload_includes_similarity_controls() -> None:
     assert payload["endPublishedDate"] == "2026-03-15"
     assert payload["excludeSourceDomain"] is True
     assert payload["moderation"] is False
-    assert payload["text"] is True
-    assert payload["highlights"] == {"highlightsPerUrl": 2, "numSentences": 1}
-    assert payload["context"] is True
+    assert payload["contents"]["text"] is True
+    assert payload["contents"]["highlights"] == {"maxCharacters": 1333}
+    assert payload["contents"]["context"] is True
+    assert_no_deprecated_request_fields(payload)
 
 
 def test_mock_exa_find_similar_response_returns_context_and_text() -> None:
@@ -163,7 +182,7 @@ def test_build_structured_search_payload_adds_output_schema() -> None:
     config.update(
         {
             "additional_queries": ["licensed public adjuster Florida"],
-            "livecrawl": True,
+            "max_age_hours": 0,
         }
     )
     output_schema = {
@@ -193,8 +212,10 @@ def test_build_structured_search_payload_adds_output_schema() -> None:
     assert payload["query"] == "insurance expert witness"
     assert payload["numResults"] == 2
     assert payload["additionalQueries"] == ["licensed public adjuster Florida"]
-    assert payload["livecrawl"] is True
+    assert payload["contents"]["maxAgeHours"] == 0
+    assert payload["contents"]["highlights"] == {"maxCharacters": 2666}
     assert payload["outputSchema"] == output_schema
+    assert_no_deprecated_request_fields(payload)
 
 
 def test_mock_exa_structured_search_response_returns_structured_output() -> None:
@@ -373,6 +394,9 @@ def test_exa_find_similar_uses_smoke_similar_shape() -> None:
     assert meta.cache_hit is False
     assert meta.request_payload["url"] == "https://example.com/article"
     assert meta.request_payload["excludeSourceDomain"] is True
-    assert meta.request_payload["text"] is True
+    assert meta.request_payload["contents"]["text"] is True
+    assert meta.request_payload["contents"]["highlights"] == {"maxCharacters": 2666}
+    assert meta.request_payload["contents"]["context"] is True
     assert meta.estimated_cost_usd == cache_store.calls[0]["estimated_cost"]
     assert cache_store.calls[0]["run_id"] == "similar-run"
+    assert_no_deprecated_request_fields(meta.request_payload)

--- a/tests/test_cost_model.py
+++ b/tests/test_cost_model.py
@@ -19,7 +19,7 @@ def test_estimate_cost_accounts_for_search_and_contents() -> None:
     payload = {
         "contents": {
             "text": True,
-            "highlights": {"highlightsPerUrl": 1, "numSentences": 2},
+            "highlights": {"maxCharacters": 2666},
         }
     }
 

--- a/tests/test_workflow_builders.py
+++ b/tests/test_workflow_builders.py
@@ -27,6 +27,10 @@ def test_build_exa_payload_trims_additional_queries_and_dates() -> None:
     assert payload['additionalQueries'] == ['licensed public adjuster Florida']
     assert payload['startPublishedDate'] == '2026-01-01'
     assert 'endPublishedDate' not in payload
+    assert payload['contents']['highlights'] == {'maxCharacters': 2666}
+    assert 'livecrawl' not in payload
+    assert 'highlightsPerUrl' not in payload['contents']['highlights']
+    assert 'numSentences' not in payload['contents']['highlights']
 
 
 def test_build_find_similar_payload_trims_optional_date_filters() -> None:
@@ -43,6 +47,7 @@ def test_build_find_similar_payload_trims_optional_date_filters() -> None:
     assert payload['startPublishedDate'] == '2026-01-15'
     assert 'endCrawlDate' not in payload
     assert 'endPublishedDate' not in payload
+    assert payload['contents']['text'] is True
 
 
 def test_build_answer_artifact_normalizes_base_fields() -> None:


### PR DESCRIPTION
## Summary
- Replace deprecated search payload freshness/highlight controls with `contents.maxAgeHours` and `contents.highlights.maxCharacters`.
- Add CLI freshness controls: `--max-age-hours` and `--freshness {default,cache-only,daily,near-real-time,always-live}`.
- Keep `--livecrawl` as a deprecated compatibility alias that maps to `maxAgeHours: 0`.
- Update smoke/cost helpers and tests so search, structured-search, and eval request payloads prove deprecated fields are absent.

## Validation
- `python -m ruff check .`
- `python -m pytest -q` (269 passed, 1 existing Jupyter path deprecation warning)
- `python scripts/run_live_validation.py --mode smoke`

Closes #45