### PR TITLE
Preserve Exa grounding in artifacts and reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ Core local resources:
 | Benchmark evaluation | Done | `python -m exa_demo eval` | `queries.jsonl`, `results.jsonl`, `summary.json` | Includes taxonomy scoring and grouped comparison context |
 | Search-type comparison | Done | `python -m exa_demo compare-search-types` | `comparison.md` plus paired run artifacts | Compares `deep` vs `deep-reasoning` end to end |
 | Cited answers | Done | `python -m exa_demo answer` | `answer.json` | Separate workflow from ranked-search evaluation |
-| Research reports | Done | `python -m exa_demo research` | `research.json` | Report-style workflow backed by `/search` with `type="deep-reasoning"` |
-| Structured extraction | Done | `python -m exa_demo structured-search` | `structured_output.json` | Uses `outputSchema` for schema-driven extraction |
+| Research reports | Done | `python -m exa_demo research` | `research.json` | Report-style workflow backed by `/search` with `type="deep-reasoning"`; preserves `output.content` and `output.grounding` when returned |
+| Structured extraction | Done | `python -m exa_demo structured-search` | `structured_output.json` | Uses `outputSchema` for schema-driven extraction; preserves `output.content` and `output.grounding` outside the schema payload |
 | Seed-URL discovery | Done | `python -m exa_demo find-similar` | `find_similar.json` | Separate `/findSimilar` workflow and normalization path |
 | Cache and budget ledger | Done | Notebook + CLI | `exa_cache.sqlite`, `summary.json` | Prevents re-billing on cache hits |
 | API server | Done | `uvicorn exa_demo.api:app` | JSON responses | Thin FastAPI wrapper over CLI workflows; smoke mode first-class |
@@ -242,6 +242,7 @@ The search and eval commands write the same `experiments/<RUN_ID>/` artifact bun
 The `answer` command writes the same run directory and adds an `answer.json` artifact containing the cited-answer payload.
 The `research` command writes the same run directory and adds `research.json` plus `research.md` artifacts for a `/search` `type="deep-reasoning"` research-report payload.
 The `structured-search` command runs a schema-driven deep search and writes a `structured_output.json` artifact containing the extracted structured payload.
+When Exa returns `output.grounding`, research and structured-search artifacts preserve it as separate `grounding` metadata beside `output_content`; Markdown reports add a compact `Grounding / Source Review` section.
 The `find-similar` command runs a seed-URL discovery workflow and writes a `find_similar.json` artifact containing the similar-result payload.
 The endpoint-style workflows (`answer`, `research`, `structured-search`, and `find-similar`) also emit a reusable `report.md` companion artifact for human review.
 Eval workflows also emit additive export companions such as `results.csv`, `comparison.json`, `grouped_query_outcomes.csv`, and `manifest.json` without changing the existing JSON/JSONL contracts.

--- a/docs/adr/ADR-0002-exa-2026-modernization.md
+++ b/docs/adr/ADR-0002-exa-2026-modernization.md
@@ -25,7 +25,7 @@ The important boundary is that `research` is a product/workflow name in this rep
 - README and docs should describe `research` as search-backed rather than as an Exa `/research` endpoint.
 - Freshness docs should prefer `--freshness always-live` or `--max-age-hours 0`; older `--livecrawl` examples should not be used.
 - Pricing assumptions should stay centralized in `DEFAULT_PRICING`, remain overrideable from the CLI, and avoid exact live-billing claims unless live Exa `costDollars` fields validate the run.
-- Grounding metadata handling remains a separate follow-up from request modernization and cost estimation.
+- Grounding metadata handling is additive to request modernization: keep `output.content` as workflow content and preserve `output.grounding` as separate artifact metadata when present.
 
 ## Related Roadmap Items or Issues
 

--- a/docs/demo-gallery.md
+++ b/docs/demo-gallery.md
@@ -36,6 +36,8 @@ python -m exa_demo answer "What is the Florida appraisal clause dispute process?
 python -m exa_demo research "Summarize the Florida CAT market outlook." --mode smoke --json
 ```
 
+When Exa returns `output.grounding`, `research.json`, `research.md`, and `report.md` keep that source-review metadata separate from the report body.
+
 ## Extraction
 
 `structured-search` is the schema-driven extraction workflow. Use it when you want Exa to return a typed payload that can be normalized into downstream tables, graphs, or datasets.
@@ -43,6 +45,8 @@ python -m exa_demo research "Summarize the Florida CAT market outlook." --mode s
 ```powershell
 python -m exa_demo structured-search "independent adjuster florida catastrophe claims" --schema-file path/to/structured-schema.json --mode smoke --json
 ```
+
+Structured-search artifacts preserve `output.content` and `output.grounding` as separate artifact fields, without adding citation or grounding fields to the requested schema.
 
 ## Comparison
 

--- a/scripts/run_live_validation.py
+++ b/scripts/run_live_validation.py
@@ -111,6 +111,7 @@ def build_validation_commands(
     include_comparison: bool,
 ) -> List[Dict[str, Any]]:
     schema_path = repo_root / "assets" / "live_validation_schema.json"
+    sqlite_path = artifact_dir / f"{run_id_prefix}.sqlite"
     base_command = [sys.executable, "-m", "exa_demo"]
 
     commands: List[Dict[str, Any]] = [
@@ -127,6 +128,8 @@ def build_validation_commands(
                 f"{run_id_prefix}-search",
                 "--artifact-dir",
                 str(artifact_dir),
+                "--sqlite-path",
+                str(sqlite_path),
                 "--json",
             ],
         },
@@ -143,6 +146,8 @@ def build_validation_commands(
                 f"{run_id_prefix}-answer",
                 "--artifact-dir",
                 str(artifact_dir),
+                "--sqlite-path",
+                str(sqlite_path),
                 "--json",
             ],
         },
@@ -159,6 +164,8 @@ def build_validation_commands(
                 f"{run_id_prefix}-research",
                 "--artifact-dir",
                 str(artifact_dir),
+                "--sqlite-path",
+                str(sqlite_path),
                 "--json",
             ],
         },
@@ -177,6 +184,8 @@ def build_validation_commands(
                 f"{run_id_prefix}-structured",
                 "--artifact-dir",
                 str(artifact_dir),
+                "--sqlite-path",
+                str(sqlite_path),
                 "--json",
             ],
         },
@@ -193,6 +202,8 @@ def build_validation_commands(
                 f"{run_id_prefix}-find-similar",
                 "--artifact-dir",
                 str(artifact_dir),
+                "--sqlite-path",
+                str(sqlite_path),
                 "--json",
             ],
         },
@@ -212,6 +223,8 @@ def build_validation_commands(
                     f"{run_id_prefix}-compare",
                     "--artifact-dir",
                     str(artifact_dir),
+                    "--sqlite-path",
+                    str(sqlite_path),
                     "--suite",
                     "forensic_and_damage_engineering",
                     "--limit",

--- a/src/exa_demo/endpoint_workflows.py
+++ b/src/exa_demo/endpoint_workflows.py
@@ -167,8 +167,9 @@ def run_research_workflow(
         "research.md",
         render_research_markdown(
             query=query,
-            report_text=record.report_text or "",
-            citations=[citation.to_dict() for citation in record.citations],
+            report_text=research_payload["report_text"],
+            citations=research_payload["citations"],
+            grounding=research_payload.get("grounding"),
         ),
         kind="markdown",
     )

--- a/src/exa_demo/reporting.py
+++ b/src/exa_demo/reporting.py
@@ -268,6 +268,7 @@ def render_research_markdown(
     query: str,
     report_text: str,
     citations: List[Mapping[str, Any]] | None = None,
+    grounding: List[Mapping[str, Any]] | None = None,
 ) -> str:
     lines: List[str] = []
     lines.append("# Research Report")
@@ -292,6 +293,7 @@ def render_research_markdown(
                 lines.append(f"- {title}")
             if snippet:
                 lines.append(f"  - {snippet}")
+    _append_grounding_section(lines, grounding)
     return "\n".join(lines).strip() + "\n"
 
 
@@ -339,6 +341,7 @@ def render_endpoint_report_markdown(
         lines.append("")
         lines.append(str(payload.get("report_text") or "No report text returned.").strip())
         _append_citations_section(lines, payload.get("citations"))
+        _append_grounding_section(lines, payload.get("grounding"))
     elif workflow == "structured-search":
         lines.append("## Structured Output")
         lines.append("")
@@ -353,6 +356,7 @@ def render_endpoint_report_markdown(
         lines.append("```json")
         lines.append(json.dumps(structured_output, indent=2, sort_keys=True, ensure_ascii=False))
         lines.append("```")
+        _append_grounding_section(lines, payload.get("grounding"))
     elif workflow == "find-similar":
         top_result = payload.get("top_result")
         lines.append("## Top Result")
@@ -423,6 +427,41 @@ def _append_citations_section(lines: List[str], citations: Any) -> None:
             lines.append(f"- {title}")
         if snippet:
             lines.append(f"  Snippet: {snippet}")
+
+
+def _append_grounding_section(lines: List[str], grounding: Any) -> None:
+    if not isinstance(grounding, list) or not grounding:
+        return
+
+    items = [item for item in grounding if isinstance(item, Mapping)]
+    if not items:
+        return
+
+    lines.append("")
+    lines.append("## Grounding / Source Review")
+    lines.append("")
+    for index, item in enumerate(items[:5], start=1):
+        title = str(item.get("title") or f"Source {index}").strip()
+        url = str(item.get("url") or item.get("sourceUrl") or "").strip()
+        snippet = _grounding_snippet(item)
+        if url:
+            lines.append(f"{index}. [{title}]({url})")
+        else:
+            lines.append(f"{index}. {title}")
+        if snippet:
+            lines.append(f"   Source note: {snippet}")
+    if len(items) > 5:
+        lines.append(f"{len(items) - 5} additional grounding sources omitted.")
+
+
+def _grounding_snippet(item: Mapping[str, Any]) -> str:
+    for key in ("snippet", "summary", "text", "quote", "passage"):
+        value = item.get(key)
+        if value is not None:
+            text = str(value).strip()
+            if text:
+                return text[:240]
+    return ""
 
 
 def _append_find_similar_result(lines: List[str], result: Mapping[str, Any]) -> None:

--- a/src/exa_demo/workflows.py
+++ b/src/exa_demo/workflows.py
@@ -41,6 +41,8 @@ def build_research_artifact(
     estimated_cost_usd: float,
 ) -> Dict[str, Any]:
     report_text = _extract_research_report_text(response_json)
+    output_content = _extract_output_content(response_json)
+    grounding = _extract_output_grounding(response_json)
     citations = _normalize_citations(
         response_json.get("citations")
         if isinstance(response_json.get("citations"), list)
@@ -55,6 +57,11 @@ def build_research_artifact(
         "citation_count": len(citations),
         "citations": citations,
     }
+    if output_content is not None:
+        payload["output_content"] = output_content
+    if grounding:
+        payload["grounding"] = grounding
+        payload["grounding_count"] = len(grounding)
     return {
         **_artifact_base(
             request_payload=request_payload,
@@ -105,12 +112,19 @@ def build_structured_search_artifact(
     estimated_cost_usd: float,
 ) -> Dict[str, Any]:
     structured_output = _extract_structured_output(response_json)
+    output_content = _extract_output_content(response_json)
+    grounding = _extract_output_grounding(response_json)
     payload = {
         "query": query,
         "schema_file": str(schema_path),
         "structured_output": structured_output,
         "structured_output_keys": sorted(structured_output.keys()) if isinstance(structured_output, Mapping) else [],
     }
+    if output_content is not None:
+        payload["output_content"] = output_content
+    if grounding:
+        payload["grounding"] = grounding
+        payload["grounding_count"] = len(grounding)
     return {
         **_artifact_base(
             request_payload=request_payload,
@@ -282,6 +296,76 @@ def _output_content_text(response_json: Mapping[str, Any]) -> str:
     return ""
 
 
+def _extract_output_content(response_json: Mapping[str, Any]) -> Any | None:
+    if not isinstance(response_json, Mapping):
+        return None
+
+    output = response_json.get("output")
+    if not isinstance(output, Mapping) or "content" not in output:
+        return None
+
+    content = output.get("content")
+    if content is None:
+        return None
+    return _jsonable_value(content)
+
+
+def _extract_output_grounding(response_json: Mapping[str, Any]) -> list[Dict[str, Any]]:
+    if not isinstance(response_json, Mapping):
+        return []
+
+    output = response_json.get("output")
+    if not isinstance(output, Mapping):
+        return []
+
+    return _normalize_grounding(output.get("grounding"))
+
+
+def _normalize_grounding(value: Any) -> list[Dict[str, Any]]:
+    if isinstance(value, list):
+        raw_items = value
+    elif isinstance(value, Mapping):
+        raw_items = [value]
+    else:
+        return []
+
+    grounding: list[Dict[str, Any]] = []
+    for item in raw_items:
+        normalized = _normalize_grounding_item(item)
+        if normalized:
+            grounding.append(normalized)
+    return grounding
+
+
+def _normalize_grounding_item(value: Any) -> Dict[str, Any]:
+    if isinstance(value, Mapping):
+        item = _jsonable_mapping(value)
+        title = _clean_string(
+            value.get("title") or value.get("name") or value.get("sourceTitle")
+        )
+        url = _clean_string(value.get("url") or value.get("sourceUrl") or value.get("uri"))
+        snippet = _clean_string(
+            value.get("snippet")
+            or value.get("summary")
+            or value.get("text")
+            or value.get("quote")
+            or value.get("passage")
+        )
+        if title:
+            item["title"] = title
+        if url:
+            item["url"] = url
+        if snippet:
+            item["snippet"] = snippet
+        return item
+
+    if isinstance(value, (str, int, float, bool)):
+        text = _clean_string(value)
+        if text:
+            return {"snippet": text}
+    return {}
+
+
 def load_json_schema(schema_path: Path) -> Dict[str, Any]:
     schema_text = schema_path.read_text(encoding="utf-8")
     schema = json.loads(schema_text)
@@ -312,6 +396,10 @@ def _jsonable_mapping(value: Mapping[str, Any]) -> Dict[str, Any]:
     return json.loads(json.dumps(dict(value), ensure_ascii=False, default=str))
 
 
+def _jsonable_value(value: Any) -> Any:
+    return json.loads(json.dumps(value, ensure_ascii=False, default=str))
+
+
 def _request_id(response_json: Mapping[str, Any]) -> str | None:
     if not isinstance(response_json, Mapping):
         return None
@@ -329,3 +417,9 @@ def _coerce_optional_float(value: Any) -> float | None:
         return float(value)
     except (TypeError, ValueError):
         return None
+
+
+def _clean_string(value: Any) -> str:
+    if value is None:
+        return ""
+    return str(value).strip()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -159,6 +159,15 @@ def test_research_smoke(client):
     assert artifact_payload["request_payload"]["contents"]["highlights"] == {
         "maxCharacters": 2666
     }
+    assert artifact_payload["output_content"].startswith("Search-backed research report.")
+    assert artifact_payload["grounding_count"] == 5
+    assert artifact_payload["grounding"][0]["title"] == "Mock Research Source 1"
+    assert artifact_payload["grounding"][0]["url"].startswith("https://example.com/mock-research/")
+    assert "grounding" not in artifact_payload["output_content"]
+    report_markdown = (Path(data["artifact_dir"]) / "report.md").read_text(encoding="utf-8")
+    research_markdown = (Path(data["artifact_dir"]) / "research.md").read_text(encoding="utf-8")
+    assert "## Grounding / Source Review" in report_markdown
+    assert "## Grounding / Source Review" in research_markdown
     assert_no_deprecated_request_fields(artifact_payload["request_payload"])
 
 
@@ -214,6 +223,20 @@ def test_structured_search_smoke(client):
     assert data["workflow"] == "structured-search"
     assert "run_id" in data
     assert "summary" in data
+    artifact_payload = json.loads(
+        (Path(data["artifact_dir"]) / "structured_output.json").read_text(encoding="utf-8")
+    )
+    assert artifact_payload["grounding_count"] == 5
+    assert artifact_payload["grounding"][0]["url"].startswith("https://www.linkedin.com/")
+    assert artifact_payload["output_content"]["name"].startswith("Mock name for query:")
+    assert "grounding" not in artifact_payload["output_content"]
+    assert "citations" not in artifact_payload["output_content"]
+    assert "confidence" not in artifact_payload["output_content"]
+    assert "grounding" not in artifact_payload["request_payload"]["outputSchema"]["properties"]
+    assert "citations" not in artifact_payload["request_payload"]["outputSchema"]["properties"]
+    assert "confidence" not in artifact_payload["request_payload"]["outputSchema"]["properties"]
+    report_markdown = (Path(data["artifact_dir"]) / "report.md").read_text(encoding="utf-8")
+    assert "## Grounding / Source Review" in report_markdown
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -677,10 +677,15 @@ def test_research_command_smoke_emits_json_and_artifact(tmp_path, capsys) -> Non
     research_payload = json.loads((artifact_dir / 'research-run' / 'research.json').read_text(encoding='utf-8'))
     assert research_payload['citation_count'] == 5
     assert research_payload['citations'][0]['title'] == 'Mock Research Source 1'
+    assert research_payload['grounding_count'] == 5
+    assert research_payload['grounding'][0]['title'] == 'Mock Research Source 1'
+    assert research_payload['output_content'].startswith('Search-backed research report.')
     assert research_payload['request_payload']['type'] == 'deep-reasoning'
     assert research_payload['request_payload']['contents']['highlights'] == {'maxCharacters': 2666}
     assert_no_deprecated_request_fields(research_payload['request_payload'])
-    assert '# Research Report' in (artifact_dir / 'research-run' / 'research.md').read_text(encoding='utf-8')
+    research_markdown = (artifact_dir / 'research-run' / 'research.md').read_text(encoding='utf-8')
+    assert '# Research Report' in research_markdown
+    assert '## Grounding / Source Review' in research_markdown
     summary_payload = json.loads((artifact_dir / 'research-run' / 'summary.json').read_text(encoding='utf-8'))
     assert summary_payload['extra']['runtime']['execution_mode'] == 'smoke'
 
@@ -759,6 +764,10 @@ def test_structured_search_command_smoke_emits_json_and_artifact(tmp_path, capsy
     structured_payload = json.loads((artifact_dir / 'structured-run' / 'structured_output.json').read_text(encoding='utf-8'))
     assert structured_payload['structured_output']['record_count'] == 1
     assert structured_payload['structured_output_keys'] == ['field_names', 'query', 'record_count', 'records', 'schema_title']
+    assert structured_payload['grounding_count'] == 5
+    assert structured_payload['grounding'][0]['url'].startswith('https://www.linkedin.com/')
+    assert 'grounding' not in structured_payload['output_content']
+    assert 'citations' not in structured_payload['output_content']
     assert structured_payload['request_payload']['contents']['highlights'] == {'maxCharacters': 2666}
     assert_no_deprecated_request_fields(structured_payload['request_payload'])
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -256,6 +256,9 @@ def test_mock_exa_structured_search_response_returns_structured_output() -> None
     assert response["structuredOutput"]["professionals"][0]["name"].startswith("Mock name for query:")
     assert response["output"]["content"] == response["structuredOutput"]
     assert response["output"]["grounding"][0]["url"].startswith("https://www.linkedin.com/")
+    assert "grounding" not in response["output"]["content"]
+    assert "citations" not in response["output"]["content"]
+    assert "confidence" not in response["output"]["content"]
     assert len(response["results"]) == payload["numResults"]
 
 

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -275,12 +275,21 @@ def test_render_research_markdown_includes_report_and_citations() -> None:
                 'snippet': 'Bulletin summary',
             }
         ],
+        grounding=[
+            {
+                'title': 'Florida market bulletin',
+                'url': 'https://example.com/bulletin',
+                'snippet': 'Grounded source summary',
+            }
+        ],
     )
 
     assert '# Research Report' in markdown
     assert 'Summarize the Florida CAT market outlook.' in markdown
     assert 'Mock research report body.' in markdown
     assert '[Florida market bulletin](https://example.com/bulletin)' in markdown
+    assert '## Grounding / Source Review' in markdown
+    assert 'Source note: Grounded source summary' in markdown
 
 
 def test_render_endpoint_report_markdown_for_answer_includes_summary_and_citations() -> None:
@@ -319,6 +328,13 @@ def test_render_endpoint_report_markdown_for_structured_search_includes_json_blo
             'schema_file': 'schema.json',
             'structured_output_keys': ['field_names', 'records'],
             'structured_output': {'field_names': ['name'], 'records': [{'name': 'Jane Doe'}]},
+            'grounding': [
+                {
+                    'title': 'Jane Doe profile',
+                    'url': 'https://example.com/jane-doe',
+                    'snippet': 'Profile source used for extraction.',
+                }
+            ],
             'cache_hit': True,
         },
         summary={'request_count': 1, 'spent_usd': 0.02},
@@ -328,4 +344,5 @@ def test_render_endpoint_report_markdown_for_structured_search_includes_json_blo
     assert '- Schema file: `schema.json`' in markdown
     assert '"name": "Jane Doe"' in markdown
     assert '```json' in markdown
-
+    assert '## Grounding / Source Review' in markdown
+    assert '[Jane Doe profile](https://example.com/jane-doe)' in markdown

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -328,6 +328,7 @@ def test_run_live_validation_smoke_writes_summary(tmp_path, monkeypatch, capsys)
     assert summary_payload['commands'][0]['validated_artifacts']
     assert summary_payload['commands'][-1]['name'] == 'compare-search-types'
     assert any(path.endswith('comparison.md') for path in summary_payload['commands'][-1]['validated_artifacts'])
+    assert '--sqlite-path' in calls[0]['argv']
 
 
 def test_run_live_validation_live_requires_request_ids_for_single_workflows(
@@ -398,5 +399,11 @@ def test_build_validation_commands_includes_smoke_workflows(tmp_path) -> None:
         'structured-search',
         'find-similar',
     ]
-    assert commands[0]['argv'][-3:] == ['--artifact-dir', str(artifact_dir), '--json']
+    assert commands[0]['argv'][-5:] == [
+        '--artifact-dir',
+        str(artifact_dir),
+        '--sqlite-path',
+        str(artifact_dir / 'ci-smoke.sqlite'),
+        '--json',
+    ]
     assert '--include-comparison' not in ' '.join(str(part) for part in commands[-1]['argv'])

--- a/tests/test_workflow_builders.py
+++ b/tests/test_workflow_builders.py
@@ -174,6 +174,10 @@ def test_build_research_artifact_reads_modern_output_content() -> None:
 
     assert payload['request_id'] == 'req-research-output'
     assert payload['report_text'] == 'Modern research report from output content.'
+    assert payload['output_content'] == 'Modern research report from output content.'
+    assert payload['grounding_count'] == 1
+    assert payload['grounding'][0]['title'] == 'Florida Market Bulletin'
+    assert payload['grounding'][0]['url'] == 'https://example.com/bulletin'
     assert payload['citation_count'] == 1
     assert payload['response']['output']['grounding'][0]['title'] == 'Florida Market Bulletin'
 
@@ -261,5 +265,10 @@ def test_build_structured_search_artifact_reads_modern_output_content(tmp_path: 
 
     assert payload['request_id'] == 'req-structured-output'
     assert payload['structured_output']['records'][0]['name'] == 'Jane Doe'
+    assert payload['output_content']['records'][0]['name'] == 'Jane Doe'
+    assert payload['grounding_count'] == 1
+    assert payload['grounding'][0]['url'] == 'https://example.com/profile'
     assert payload['structured_output_keys'] == ['records', 'schema_title']
+    assert 'grounding' not in payload['structured_output']
+    assert 'citations' not in payload['structured_output']
     assert payload['response']['output']['grounding'][0]['url'] == 'https://example.com/profile'

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -198,6 +198,8 @@ def test_run_research_workflow_smoke_writes_markdown_and_summary_context(tmp_pat
     assert 'Search-backed research report' in (payload['report'] or '')
     assert '# Research Report' in markdown
     assert '# Research Workflow Report' in report_markdown
+    assert '## Grounding / Source Review' in markdown
+    assert '## Grounding / Source Review' in report_markdown
     assert 'Mock Research Source 1' in report_markdown
     assert summary_payload['extra']['workflow'] == 'research'
     assert summary_payload['extra']['research']['citation_count'] == 5
@@ -321,6 +323,7 @@ def test_run_structured_search_workflow_smoke_writes_schema_context(tmp_path) ->
     assert payload['structured_output']['schema_title'] == 'Structured Professionals'
     assert '# Structured Search Workflow Report' in report_markdown
     assert 'Structured Professionals' in report_markdown
+    assert '## Grounding / Source Review' in report_markdown
     assert summary_payload['extra']['workflow'] == 'structured-search'
     assert summary_payload['extra']['structured_search']['schema_file'] == str(schema_file)
     assert summary_payload['extra']['structured_search']['structured_keys'] == [


### PR DESCRIPTION
## Summary

- Preserves Exa `output.content` and `output.grounding` separately for research and structured-search artifacts.
- Adds normalized grounding metadata to `research.json` and `structured_output.json`.
- Renders `## Grounding / Source Review` in Markdown reports when grounding exists.
- Updates smoke/test coverage to prove grounding survives client → workflow → artifact → report rendering.
- Makes smoke validation use run-scoped SQLite cache so stale local cache entries cannot hide updated smoke payloads.

## Validation

- `python -m ruff check .` passed
- `python -m pytest -q` passed
- `python scripts/run_live_validation.py --mode smoke` passed
- `git diff --check` passed

## Notes

- No live Exa calls were run.
- Real Exa grounding variants still need a small live validation pass later.
- Closes #53 