### PR TITLE
Harden Exa grounding artifact normalization

### DIFF
--- a/src/exa_demo/client_smoke.py
+++ b/src/exa_demo/client_smoke.py
@@ -143,25 +143,6 @@ def mock_exa_structured_search_response(payload: Mapping[str, Any]) -> Dict[str,
         else {}
     )
     structured_output = _mock_structured_output(schema, query)
-    properties = (
-        schema.get("properties") if isinstance(schema.get("properties"), Mapping) else {}
-    )
-    structured_data = {
-        "query": query,
-        "schema_title": str(schema.get("title") or "structured-output"),
-        "field_names": sorted(str(key) for key in properties.keys()),
-        "record_count": 1,
-        "records": [
-            {
-                "name": "Mock Structured Record",
-                "role": "Insurance expert witness",
-                "firm": "Mock Advisory Group",
-                "state_licenses": ["FL"],
-                "specializations": ["catastrophe claims", "appraisal"],
-                "notable_cases_or_experience": "Mock structured output for smoke testing.",
-            }
-        ],
-    }
 
     results = []
     for index in range(num_results):
@@ -169,6 +150,10 @@ def mock_exa_structured_search_response(payload: Mapping[str, Any]) -> Dict[str,
             "id": f"mock-{slug}-{index + 1}",
             "title": f"Mock Structured Result {index + 1} - CAT loss / insurance expert",
             "url": f"https://www.linkedin.com/in/mock-structured-{slug}-{index + 1}",
+            "snippet": (
+                f"Mock structured source {index + 1} for query: {query}. "
+                "Used only as extraction provenance in smoke validation."
+            ),
         }
         results.append(item)
 
@@ -176,7 +161,7 @@ def mock_exa_structured_search_response(payload: Mapping[str, Any]) -> Dict[str,
         "requestId": f"smoke-{slug}",
         "searchType": str(payload.get("type") or "auto"),
         "results": results,
-        "structuredData": structured_data,
+        "structuredData": structured_output,
         "structuredOutput": structured_output,
         "output": {
             "content": structured_output,
@@ -306,7 +291,7 @@ def _grounding_from_results(results: list[Mapping[str, Any]]) -> list[Dict[str, 
         if url:
             source["url"] = url
         if snippet:
-            source["snippet"] = snippet
+            source["snippet"] = f"Grounding basis - {snippet}"
         if source:
             grounding.append(source)
     return grounding

--- a/src/exa_demo/reporting.py
+++ b/src/exa_demo/reporting.py
@@ -449,7 +449,7 @@ def _append_grounding_section(lines: List[str], grounding: Any) -> None:
         else:
             lines.append(f"{index}. {title}")
         if snippet:
-            lines.append(f"   Source note: {snippet}")
+            lines.append(f"   Grounding note: {snippet}")
     if len(items) > 5:
         lines.append(f"{len(items) - 5} additional grounding sources omitted.")
 

--- a/src/exa_demo/workflows.py
+++ b/src/exa_demo/workflows.py
@@ -331,10 +331,28 @@ def _normalize_grounding(value: Any) -> list[Dict[str, Any]]:
 
     grounding: list[Dict[str, Any]] = []
     for item in raw_items:
-        normalized = _normalize_grounding_item(item)
-        if normalized:
-            grounding.append(normalized)
+        grounding.extend(_normalize_grounding_items(item))
     return grounding
+
+
+def _normalize_grounding_items(value: Any) -> list[Dict[str, Any]]:
+    normalized = _normalize_grounding_item(value)
+    if isinstance(value, Mapping):
+        citations = value.get("citations")
+        if isinstance(citations, list):
+            normalized_citations = [
+                normalized_citation
+                for citation in citations
+                if (normalized_citation := _normalize_grounding_item(citation))
+            ]
+            if normalized_citations:
+                if normalized:
+                    return [normalized, *normalized_citations]
+                return normalized_citations
+
+    if normalized:
+        return [normalized]
+    return []
 
 
 def _normalize_grounding_item(value: Any) -> Dict[str, Any]:

--- a/src/exa_demo/workflows.py
+++ b/src/exa_demo/workflows.py
@@ -56,12 +56,12 @@ def build_research_artifact(
         "report_preview": report_text[:220],
         "citation_count": len(citations),
         "citations": citations,
+        "grounding_count": len(grounding),
     }
     if output_content is not None:
         payload["output_content"] = output_content
     if grounding:
         payload["grounding"] = grounding
-        payload["grounding_count"] = len(grounding)
     return {
         **_artifact_base(
             request_payload=request_payload,
@@ -119,12 +119,12 @@ def build_structured_search_artifact(
         "schema_file": str(schema_path),
         "structured_output": structured_output,
         "structured_output_keys": sorted(structured_output.keys()) if isinstance(structured_output, Mapping) else [],
+        "grounding_count": len(grounding),
     }
     if output_content is not None:
         payload["output_content"] = output_content
     if grounding:
         payload["grounding"] = grounding
-        payload["grounding_count"] = len(grounding)
     return {
         **_artifact_base(
             request_payload=request_payload,
@@ -339,18 +339,28 @@ def _normalize_grounding(value: Any) -> list[Dict[str, Any]]:
 
 def _normalize_grounding_item(value: Any) -> Dict[str, Any]:
     if isinstance(value, Mapping):
-        item = _jsonable_mapping(value)
-        title = _clean_string(
-            value.get("title") or value.get("name") or value.get("sourceTitle")
-        )
-        url = _clean_string(value.get("url") or value.get("sourceUrl") or value.get("uri"))
-        snippet = _clean_string(
-            value.get("snippet")
-            or value.get("summary")
-            or value.get("text")
-            or value.get("quote")
-            or value.get("passage")
-        )
+        source = value.get("source")
+        source_mapping = source if isinstance(source, Mapping) else {}
+        title = _first_clean_string(value, "title", "name", "sourceTitle")
+        if not title and source_mapping:
+            title = _first_clean_string(source_mapping, "title", "name", "sourceTitle")
+
+        url = _first_clean_string(value, "url", "sourceUrl", "uri")
+        if not url and source_mapping:
+            url = _first_clean_string(source_mapping, "url", "sourceUrl", "uri")
+
+        snippet = _first_clean_string(value, "snippet", "summary", "text", "quote", "passage")
+        if not snippet and source_mapping:
+            snippet = _first_clean_string(
+                source_mapping,
+                "snippet",
+                "summary",
+                "text",
+                "quote",
+                "passage",
+            )
+
+        item: Dict[str, Any] = {}
         if title:
             item["title"] = title
         if url:
@@ -423,3 +433,11 @@ def _clean_string(value: Any) -> str:
     if value is None:
         return ""
     return str(value).strip()
+
+
+def _first_clean_string(mapping: Mapping[str, Any], *keys: str) -> str:
+    for key in keys:
+        text = _clean_string(mapping.get(key))
+        if text:
+            return text
+    return ""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -163,11 +163,14 @@ def test_research_smoke(client):
     assert artifact_payload["grounding_count"] == 5
     assert artifact_payload["grounding"][0]["title"] == "Mock Research Source 1"
     assert artifact_payload["grounding"][0]["url"].startswith("https://example.com/mock-research/")
+    assert artifact_payload["grounding"][0]["snippet"].startswith("Grounding basis - ")
+    assert artifact_payload["grounding"][0]["snippet"] != artifact_payload["citations"][0]["snippet"]
     assert "grounding" not in artifact_payload["output_content"]
     report_markdown = (Path(data["artifact_dir"]) / "report.md").read_text(encoding="utf-8")
     research_markdown = (Path(data["artifact_dir"]) / "research.md").read_text(encoding="utf-8")
     assert "## Grounding / Source Review" in report_markdown
     assert "## Grounding / Source Review" in research_markdown
+    assert "Grounding note: Grounding basis - " in report_markdown
     assert_no_deprecated_request_fields(artifact_payload["request_payload"])
 
 
@@ -228,7 +231,9 @@ def test_structured_search_smoke(client):
     )
     assert artifact_payload["grounding_count"] == 5
     assert artifact_payload["grounding"][0]["url"].startswith("https://www.linkedin.com/")
+    assert artifact_payload["grounding"][0]["snippet"].startswith("Grounding basis - ")
     assert artifact_payload["output_content"]["name"].startswith("Mock name for query:")
+    assert artifact_payload["structured_output"] == artifact_payload["output_content"]
     assert "grounding" not in artifact_payload["output_content"]
     assert "citations" not in artifact_payload["output_content"]
     assert "confidence" not in artifact_payload["output_content"]
@@ -237,6 +242,7 @@ def test_structured_search_smoke(client):
     assert "confidence" not in artifact_payload["request_payload"]["outputSchema"]["properties"]
     report_markdown = (Path(data["artifact_dir"]) / "report.md").read_text(encoding="utf-8")
     assert "## Grounding / Source Review" in report_markdown
+    assert "Grounding note: Grounding basis - " in report_markdown
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -679,6 +679,8 @@ def test_research_command_smoke_emits_json_and_artifact(tmp_path, capsys) -> Non
     assert research_payload['citations'][0]['title'] == 'Mock Research Source 1'
     assert research_payload['grounding_count'] == 5
     assert research_payload['grounding'][0]['title'] == 'Mock Research Source 1'
+    assert research_payload['grounding'][0]['snippet'].startswith('Grounding basis - ')
+    assert research_payload['grounding'][0]['snippet'] != research_payload['citations'][0]['snippet']
     assert research_payload['output_content'].startswith('Search-backed research report.')
     assert research_payload['request_payload']['type'] == 'deep-reasoning'
     assert research_payload['request_payload']['contents']['highlights'] == {'maxCharacters': 2666}
@@ -756,16 +758,17 @@ def test_structured_search_command_smoke_emits_json_and_artifact(tmp_path, capsy
     assert output['workflow'] == 'structured-search'
     assert output['run_id'] == 'structured-run'
     assert output['schema_file'] == str(schema_file)
-    assert output['structured_output']['schema_title'] == 'Structured Professionals'
-    assert output['structured_output']['field_names'] == ['name', 'role']
+    assert output['structured_output']['name'].startswith('Mock name for query:')
+    assert output['structured_output']['role'].startswith('Mock role for query:')
     assert (artifact_dir / 'structured-run' / 'structured_output.json').exists()
     assert (artifact_dir / 'structured-run' / 'report.md').exists()
     assert (artifact_dir / 'structured-run' / 'summary.json').exists()
     structured_payload = json.loads((artifact_dir / 'structured-run' / 'structured_output.json').read_text(encoding='utf-8'))
-    assert structured_payload['structured_output']['record_count'] == 1
-    assert structured_payload['structured_output_keys'] == ['field_names', 'query', 'record_count', 'records', 'schema_title']
+    assert structured_payload['structured_output'] == structured_payload['output_content']
+    assert structured_payload['structured_output_keys'] == ['name', 'role']
     assert structured_payload['grounding_count'] == 5
     assert structured_payload['grounding'][0]['url'].startswith('https://www.linkedin.com/')
+    assert structured_payload['grounding'][0]['snippet'].startswith('Grounding basis - ')
     assert 'grounding' not in structured_payload['output_content']
     assert 'citations' not in structured_payload['output_content']
     assert structured_payload['request_payload']['contents']['highlights'] == {'maxCharacters': 2666}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -254,8 +254,10 @@ def test_mock_exa_structured_search_response_returns_structured_output() -> None
     assert response["searchType"] == "auto"
     assert response["structuredOutput"]["summary"].startswith("Mock summary for query:")
     assert response["structuredOutput"]["professionals"][0]["name"].startswith("Mock name for query:")
+    assert response["structuredData"] == response["structuredOutput"]
     assert response["output"]["content"] == response["structuredOutput"]
     assert response["output"]["grounding"][0]["url"].startswith("https://www.linkedin.com/")
+    assert response["output"]["grounding"][0]["snippet"].startswith("Grounding basis - ")
     assert "grounding" not in response["output"]["content"]
     assert "citations" not in response["output"]["content"]
     assert "confidence" not in response["output"]["content"]
@@ -306,6 +308,8 @@ def test_mock_exa_research_response_returns_search_results() -> None:
     assert response["results"][0]["url"].startswith("https://example.com/mock-research/")
     assert response["output"]["content"].startswith("Search-backed research report.")
     assert response["output"]["grounding"][0]["title"] == "Mock Research Source 1"
+    assert response["output"]["grounding"][0]["snippet"].startswith("Grounding basis - ")
+    assert response["output"]["grounding"][0]["snippet"] != response["results"][0]["snippet"]
     assert "report" not in response
     assert "citations" not in response
 

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -289,7 +289,7 @@ def test_render_research_markdown_includes_report_and_citations() -> None:
     assert 'Mock research report body.' in markdown
     assert '[Florida market bulletin](https://example.com/bulletin)' in markdown
     assert '## Grounding / Source Review' in markdown
-    assert 'Source note: Grounded source summary' in markdown
+    assert 'Grounding note: Grounded source summary' in markdown
 
 
 def test_render_endpoint_report_markdown_for_answer_includes_summary_and_citations() -> None:
@@ -346,3 +346,4 @@ def test_render_endpoint_report_markdown_for_structured_search_includes_json_blo
     assert '```json' in markdown
     assert '## Grounding / Source Review' in markdown
     assert '[Jane Doe profile](https://example.com/jane-doe)' in markdown
+    assert 'Grounding note: Profile source used for extraction.' in markdown

--- a/tests/test_workflow_builders.py
+++ b/tests/test_workflow_builders.py
@@ -156,6 +156,14 @@ def test_build_research_artifact_reads_modern_output_content() -> None:
                     {
                         'title': 'Florida Market Bulletin',
                         'url': 'https://example.com/bulletin',
+                        'quote': 'Grounded market signal.',
+                        'email': 'analyst@example.com',
+                        'internal_id': 'private-123',
+                        'unexpected': {'nested': 'value'},
+                    },
+                    {
+                        'email': 'unsafe-only@example.com',
+                        'internal_id': 'private-456',
                     }
                 ],
             },
@@ -176,10 +184,33 @@ def test_build_research_artifact_reads_modern_output_content() -> None:
     assert payload['report_text'] == 'Modern research report from output content.'
     assert payload['output_content'] == 'Modern research report from output content.'
     assert payload['grounding_count'] == 1
-    assert payload['grounding'][0]['title'] == 'Florida Market Bulletin'
-    assert payload['grounding'][0]['url'] == 'https://example.com/bulletin'
+    assert payload['grounding'][0] == {
+        'title': 'Florida Market Bulletin',
+        'url': 'https://example.com/bulletin',
+        'snippet': 'Grounded market signal.',
+    }
     assert payload['citation_count'] == 1
     assert payload['response']['output']['grounding'][0]['title'] == 'Florida Market Bulletin'
+
+
+def test_build_research_artifact_sets_zero_grounding_count_when_empty() -> None:
+    payload = build_research_artifact(
+        'Summarize the Florida CAT market outlook.',
+        request_payload={'query': 'Summarize the Florida CAT market outlook.'},
+        response_json={
+            'requestId': 'req-research-no-grounding',
+            'output': {
+                'content': 'Modern research report without grounding.',
+                'grounding': [],
+            },
+            'costDollars': {'total': 0.0},
+        },
+        cache_hit=False,
+        estimated_cost_usd=0.01,
+    )
+
+    assert payload['grounding_count'] == 0
+    assert 'grounding' not in payload
 
 
 def test_build_find_similar_artifact_sets_top_result_and_score() -> None:
@@ -252,8 +283,14 @@ def test_build_structured_search_artifact_reads_modern_output_content(tmp_path: 
                 },
                 'grounding': [
                     {
-                        'title': 'Jane Doe',
-                        'url': 'https://example.com/profile',
+                        'source': {
+                            'title': 'Jane Doe',
+                            'sourceUrl': 'https://example.com/profile',
+                            'summary': 'Profile source used for extraction.',
+                        },
+                        'email': 'jane@example.com',
+                        'internal_id': 'profile-123',
+                        'debug': {'raw': True},
                     }
                 ],
             },
@@ -267,8 +304,36 @@ def test_build_structured_search_artifact_reads_modern_output_content(tmp_path: 
     assert payload['structured_output']['records'][0]['name'] == 'Jane Doe'
     assert payload['output_content']['records'][0]['name'] == 'Jane Doe'
     assert payload['grounding_count'] == 1
-    assert payload['grounding'][0]['url'] == 'https://example.com/profile'
+    assert payload['grounding'][0] == {
+        'title': 'Jane Doe',
+        'url': 'https://example.com/profile',
+        'snippet': 'Profile source used for extraction.',
+    }
     assert payload['structured_output_keys'] == ['records', 'schema_title']
     assert 'grounding' not in payload['structured_output']
     assert 'citations' not in payload['structured_output']
-    assert payload['response']['output']['grounding'][0]['url'] == 'https://example.com/profile'
+    assert payload['response']['output']['grounding'][0]['source']['sourceUrl'] == 'https://example.com/profile'
+
+
+def test_build_structured_search_artifact_sets_zero_grounding_count_when_empty(tmp_path: Path) -> None:
+    schema_file = tmp_path / 'schema.json'
+    schema_file.write_text('{"type":"object"}\n', encoding='utf-8')
+
+    payload = build_structured_search_artifact(
+        'insurance expert witness',
+        schema_path=schema_file,
+        request_payload={'query': 'insurance expert witness'},
+        response_json={
+            'requestId': 'req-structured-no-grounding',
+            'output': {
+                'content': {'records': []},
+                'grounding': [],
+            },
+            'costDollars': {'total': 0.0},
+        },
+        cache_hit=False,
+        estimated_cost_usd=0.01,
+    )
+
+    assert payload['grounding_count'] == 0
+    assert 'grounding' not in payload

--- a/tests/test_workflow_builders.py
+++ b/tests/test_workflow_builders.py
@@ -9,6 +9,7 @@ from exa_demo.client_payloads import (
 )
 from exa_demo.config import default_config
 from exa_demo.workflows import (
+    _normalize_grounding,
     build_answer_artifact,
     build_find_similar_artifact,
     build_research_artifact,
@@ -140,6 +141,107 @@ def test_build_research_artifact_synthesizes_report_from_search_results() -> Non
     assert 'Market conditions remain dynamic.' in payload['report_text']
 
 
+def test_normalize_grounding_preserves_flat_stable_shape() -> None:
+    grounding = _normalize_grounding(
+        [
+            {
+                'title': 'Florida Market Bulletin',
+                'url': 'https://example.com/bulletin',
+                'snippet': 'Grounded market signal.',
+                'email': 'analyst@example.com',
+                'internal_id': 'private-123',
+                'unexpected': {'nested': 'value'},
+            }
+        ]
+    )
+
+    assert grounding == [
+        {
+            'title': 'Florida Market Bulletin',
+            'url': 'https://example.com/bulletin',
+            'snippet': 'Grounded market signal.',
+        }
+    ]
+    assert set(grounding[0]) == {'title', 'url', 'snippet'}
+
+
+def test_normalize_grounding_flattens_nested_citations_to_stable_shape() -> None:
+    grounding = _normalize_grounding(
+        [
+            {
+                'field': 'records[0].name',
+                'internal_id': 'grounding-wrapper-123',
+                'citations': [
+                    {
+                        'title': 'Jane Doe profile',
+                        'url': 'https://example.com/jane-doe',
+                        'snippet': 'Profile source used for extraction.',
+                        'email': 'jane@example.com',
+                        'internal_id': 'citation-123',
+                        'raw': {'debug': True},
+                    },
+                    {
+                        'title': 'CAT market note',
+                        'url': 'https://example.com/cat-market',
+                        'snippet': 'Market signal used for extraction.',
+                        'field': 'ignored citation field',
+                        'metadata': {'rank': 1},
+                    },
+                ],
+            }
+        ]
+    )
+
+    assert grounding == [
+        {
+            'title': 'Jane Doe profile',
+            'url': 'https://example.com/jane-doe',
+            'snippet': 'Profile source used for extraction.',
+        },
+        {
+            'title': 'CAT market note',
+            'url': 'https://example.com/cat-market',
+            'snippet': 'Market signal used for extraction.',
+        },
+    ]
+    assert all(set(item) <= {'title', 'url', 'snippet'} for item in grounding)
+
+
+def test_normalize_grounding_does_not_surface_unsafe_nested_fields() -> None:
+    grounding = _normalize_grounding(
+        [
+            {
+                'field': 'records[0].name',
+                'citations': [
+                    {
+                        'title': 'Jane Doe profile',
+                        'url': 'https://example.com/jane-doe',
+                        'snippet': 'Profile source used for extraction.',
+                        'email': 'jane@example.com',
+                        'internal_id': 'citation-private-123',
+                        'field': 'ignored citation field',
+                        'raw': {'debug': True},
+                        'metadata': {'rank': 1},
+                    }
+                ],
+                'email': 'wrapper@example.com',
+                'internal_id': 'wrapper-private-123',
+                'raw': {'wrapper': True},
+            }
+        ]
+    )
+
+    assert grounding == [
+        {
+            'title': 'Jane Doe profile',
+            'url': 'https://example.com/jane-doe',
+            'snippet': 'Profile source used for extraction.',
+        }
+    ]
+    unsafe_keys = {'citations', 'debug', 'email', 'field', 'internal_id', 'metadata', 'raw'}
+    assert all(unsafe_keys.isdisjoint(item) for item in grounding)
+
+
 def test_build_research_artifact_reads_modern_output_content() -> None:
     payload = build_research_artifact(
         'Summarize the Florida CAT market outlook.',
@@ -191,6 +293,52 @@ def test_build_research_artifact_reads_modern_output_content() -> None:
     }
     assert payload['citation_count'] == 1
     assert payload['response']['output']['grounding'][0]['title'] == 'Florida Market Bulletin'
+
+
+def test_build_research_artifact_counts_nested_grounding_citations() -> None:
+    payload = build_research_artifact(
+        'Summarize the Florida CAT market outlook.',
+        request_payload={
+            'query': 'Summarize the Florida CAT market outlook.',
+            'type': 'deep-reasoning',
+        },
+        response_json={
+            'requestId': 'req-research-nested-grounding',
+            'searchType': 'deep-reasoning',
+            'output': {
+                'content': 'Modern research report from output content.',
+                'grounding': [
+                    {
+                        'field': 'report.market_conditions',
+                        'internal_id': 'wrapper-private-123',
+                        'citations': [
+                            {
+                                'title': 'Florida Market Bulletin',
+                                'url': 'https://example.com/bulletin',
+                                'snippet': 'Grounded market signal.',
+                                'email': 'analyst@example.com',
+                                'internal_id': 'private-456',
+                                'raw': {'nested': 'value'},
+                            }
+                        ],
+                    }
+                ],
+            },
+            'costDollars': {'total': 0.0},
+        },
+        cache_hit=False,
+        estimated_cost_usd=0.01,
+    )
+
+    assert payload['grounding_count'] == 1
+    assert payload['grounding'] == [
+        {
+            'title': 'Florida Market Bulletin',
+            'url': 'https://example.com/bulletin',
+            'snippet': 'Grounded market signal.',
+        }
+    ]
+    assert set(payload['grounding'][0]) == {'title', 'url', 'snippet'}
 
 
 def test_build_research_artifact_sets_zero_grounding_count_when_empty() -> None:
@@ -313,6 +461,58 @@ def test_build_structured_search_artifact_reads_modern_output_content(tmp_path: 
     assert 'grounding' not in payload['structured_output']
     assert 'citations' not in payload['structured_output']
     assert payload['response']['output']['grounding'][0]['source']['sourceUrl'] == 'https://example.com/profile'
+
+
+def test_build_structured_search_artifact_counts_nested_grounding_citations(tmp_path: Path) -> None:
+    schema_file = tmp_path / 'schema.json'
+    schema_file.write_text('{"type":"object"}\n', encoding='utf-8')
+
+    payload = build_structured_search_artifact(
+        'insurance expert witness',
+        schema_path=schema_file,
+        request_payload={'query': 'insurance expert witness'},
+        response_json={
+            'requestId': 'req-structured-nested-grounding',
+            'searchType': 'auto',
+            'output': {
+                'content': {
+                    'records': [{'name': 'Jane Doe'}],
+                    'schema_title': 'Structured Professionals',
+                },
+                'grounding': [
+                    {
+                        'field': 'records[0].name',
+                        'internal_id': 'wrapper-private-123',
+                        'citations': [
+                            {
+                                'title': 'Jane Doe profile',
+                                'url': 'https://example.com/profile',
+                                'snippet': 'Profile source used for extraction.',
+                                'email': 'jane@example.com',
+                                'internal_id': 'profile-123',
+                                'debug': {'raw': True},
+                            }
+                        ],
+                    }
+                ],
+            },
+            'costDollars': {'total': 0.0},
+        },
+        cache_hit=False,
+        estimated_cost_usd=0.01,
+    )
+
+    assert payload['grounding_count'] == 1
+    assert payload['grounding'] == [
+        {
+            'title': 'Jane Doe profile',
+            'url': 'https://example.com/profile',
+            'snippet': 'Profile source used for extraction.',
+        }
+    ]
+    assert set(payload['grounding'][0]) == {'title', 'url', 'snippet'}
+    assert 'grounding' not in payload['structured_output']
+    assert 'citations' not in payload['structured_output']
 
 
 def test_build_structured_search_artifact_sets_zero_grounding_count_when_empty(tmp_path: Path) -> None:

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -200,6 +200,7 @@ def test_run_research_workflow_smoke_writes_markdown_and_summary_context(tmp_pat
     assert '# Research Workflow Report' in report_markdown
     assert '## Grounding / Source Review' in markdown
     assert '## Grounding / Source Review' in report_markdown
+    assert 'Grounding note: Grounding basis - ' in report_markdown
     assert 'Mock Research Source 1' in report_markdown
     assert summary_payload['extra']['workflow'] == 'research'
     assert summary_payload['extra']['research']['citation_count'] == 5
@@ -320,16 +321,15 @@ def test_run_structured_search_workflow_smoke_writes_schema_context(tmp_path) ->
 
     assert payload['workflow'] == 'structured-search'
     assert payload['schema_file'] == str(schema_file)
-    assert payload['structured_output']['schema_title'] == 'Structured Professionals'
+    assert payload['structured_output']['name'].startswith('Mock name for query:')
+    assert payload['structured_output']['role'].startswith('Mock role for query:')
     assert '# Structured Search Workflow Report' in report_markdown
-    assert 'Structured Professionals' in report_markdown
+    assert '"name": "Mock name for query:' in report_markdown
     assert '## Grounding / Source Review' in report_markdown
+    assert 'Grounding note: Grounding basis - ' in report_markdown
     assert summary_payload['extra']['workflow'] == 'structured-search'
     assert summary_payload['extra']['structured_search']['schema_file'] == str(schema_file)
     assert summary_payload['extra']['structured_search']['structured_keys'] == [
-        'field_names',
-        'query',
-        'record_count',
-        'records',
-        'schema_title',
+        'name',
+        'role',
     ]


### PR DESCRIPTION
## Summary
- Always includes grounding_count for research and structured-search artifacts.
- Projects normalized grounding to a stable title/url/snippet shape.
- Avoids surfacing unsafe/internal fields in first-class grounding metadata.
- Aligns smoke structured-search artifact shapes for more realistic no-network validation.

## Validation
- python -m ruff check .
- python -m pytest -q
- python scripts/run_live_validation.py --mode smoke
- git diff --check

## Notes
- No live Exa calls were run.
- Follow-up hardening from post-merge Claude review.