### PR TITLE
Issue #62: Add frontend build and lint coverage to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,32 @@ jobs:
         run: |
           python scripts/run_live_validation.py --mode smoke --run-id-prefix ci-smoke
 
+  frontend-lint-and-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Run frontend lint
+        run: npm run lint
+
+      - name: Build frontend
+        run: npm run build
+
   security:
     runs-on: ubuntu-latest
     timeout-minutes: 10


### PR DESCRIPTION
Closes #62

Summary:
- Added a dedicated frontend-lint-and-build GitHub Actions job using npm ci with frontend/package-lock.json, then npm run lint and npm run build from frontend/.
- Preserved existing Python lint/test and security jobs.

Validation:
- npm ci from frontend/
- npm run lint from frontend/
- npm run build from frontend/
- Parsed .github/workflows/ci.yml with Python YAML parser
- git diff --check

Boundaries respected:
- No deployment, preview environments, secrets, cloud infrastructure, backend code, or frontend script changes.