### PR TITLE
Issue #63: Add bounded S3/Postgres persistence validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,10 @@ EXA_SMOKE_NO_NETWORK=0
 # PILOT_ARTIFACT_STORE=local
 # PILOT_S3_BUCKET=your-pilot-bucket
 # PILOT_S3_PREFIX=artifacts/
+
+# Optional bounded real S3/Postgres validation path.
+# Use an existing bucket and a validation-scoped prefix; do not commit outputs.
+# PILOT_RUN_STORE=postgres
+# PILOT_ARTIFACT_STORE=s3
+# PILOT_S3_PREFIX=validation/pilot-persistence/
+# PILOT_VALIDATION_API_KEY=pilot-user-api-key

--- a/HEARTBEAT.md
+++ b/HEARTBEAT.md
@@ -2,12 +2,12 @@
 
 _Generated file. Regenerate with `python scripts/generate_heartbeat.py`._
 
-_Generated: 2026-05-27T20:11:07.891614+00:00_
+_Generated: 2026-05-29T23:40:31.112725+00:00_
 
 ## Current status
 - Purpose: Exa-powered insurance intelligence toolkit for CAT-loss, claims, expert, contractor, and market/regulatory research workflows.
 - Strategic role: Workflow engine plus controlled pilot web-product base for internal insurance-intelligence validation.
-- Current milestone: Phase 5 Level 1 is partially complete: the thin FastAPI wrapper, frontend shell, and pilot auth/request-boundary hardening are shipped, and the persistence baseline is in progress with additive S3/Postgres adapters plus API health self-reporting for selected persistence backends.
+- Current milestone: Phase 5 Level 1 is partially complete: the thin FastAPI wrapper, frontend shell, and pilot auth/request-boundary hardening are shipped, and the persistence baseline is in progress with additive S3/Postgres adapters, API health self-reporting for selected persistence backends, and a bounded real-service S3/Postgres validation command.
 
 ## Operating posture
 - Active Python workflow repo with package code in `src/exa_demo/`, a thin FastAPI app in the same package, and a Next.js frontend in `frontend/`. SQLite cache, budget controls, benchmark fixtures, exported artifacts, and smoke/live execution modes are already in place. Manual live validation is script-backed. The latest bounded live evidence covers only CLI `research` and `structured-search` grounding behavior; the broader local UI path remains smoke/mock.
@@ -20,18 +20,19 @@ _Generated: 2026-05-27T20:11:07.891614+00:00_
 - Durable memory must stay curated and human-reviewed; heartbeat artifacts are generated sidecars, not the source of truth.
 
 ## Top blockers
-- Phase 5 Level 1 is not complete because the persistence baseline still lacks end-to-end S3/Postgres-backed pilot validation and deployment posture; local defaults, pilot adapters, and backend self-reporting are present.
+- Phase 5 Level 1 is not complete because the persistence baseline still lacks actual external S3/Postgres-backed pilot evidence and deployment posture; local defaults, pilot adapters, backend self-reporting, and a bounded validation command are present.
 - GitHub issue numbering has drifted from the local Phase 5 roadmap IDs, so the tracker still has `TBD` GitHub URLs for those items until dedicated issues are created.
-- Broad live Exa behavior, S3/Postgres-backed runtime behavior, frontend live mode, and deployed pilot environments remain unvalidated. A bounded 2026-05-27 live CLI rerun did validate `research` and `structured-search` grounding behavior only.
+- Broad live Exa behavior, real S3/Postgres-backed runtime behavior, frontend live mode, and deployed pilot environments remain unvalidated unless the bounded validation command is run against real services. A bounded 2026-05-27 live CLI rerun did validate `research` and `structured-search` grounding behavior only.
 
 ## Docs + setup
-- Docs freshness: Workable. `README.md`, `docs/local-validation.md`, `docs/roadmap.md`, `docs/issue-tracker.md`, `docs/integration-boundaries.md`, and `docs/pilot-architecture-decision.md` reflect the current smoke/local, bounded live grounding, and persistence-in-progress posture; older March session notes remain historical and may describe pre-slice state.
+- Docs freshness: Workable. `README.md`, `docs/local-validation.md`, `docs/roadmap.md`, `docs/issue-tracker.md`, `docs/integration-boundaries.md`, and `docs/pilot-architecture-decision.md` reflect the current smoke/local, bounded live grounding, and persistence-in-progress posture with a real-service S3/Postgres validation command; older March session notes remain historical and may describe pre-slice state.
 - Setup friction: Moderate. Python setup is straightforward, but full local work spans Python deps, optional `[api]` extras, a separate `frontend/` npm install and env file, and deliberate handling of smoke versus live mode with `EXA_API_KEY` only for bounded manual validation.
 
 ## Validation path
 - `python -m ruff check .`
 - `python -m pytest -q`
 - `python scripts/run_live_validation.py --mode smoke`
+- `python scripts/run_pilot_persistence_validation.py --output live-validation-artifacts/pilot-s3-postgres-validation.json` only in an environment with real Postgres, S3, and AWS credentials
 - `uvicorn exa_demo.api:app --reload`
 - `cd frontend` then `npm install`, copy `.env.local.example` to `.env.local`, and run `npm run dev`
 
@@ -47,6 +48,7 @@ _Generated: 2026-05-27T20:11:07.891614+00:00_
 - `docs/sessions/2026-03-22-api-wrapper.md`
 - `docs/sessions/2026-03-22-frontend-shell.md`
 - `scripts/run_live_validation.py`
+- `scripts/run_pilot_persistence_validation.py`
 - `scripts/run_notebook_smoke.py`
 
 ## Safe automation now
@@ -60,18 +62,25 @@ _Generated: 2026-05-27T20:11:07.891614+00:00_
 - Scope beyond this scaffold into auth redesign, persistence redesign, async jobs, deployment, infra, or broader docs refactors.
 
 ## Last session
-- Date: 2026-05-27
-- Objective: Sync repo docs/status after the Exa 2026 modernization, cost-model reconciliation, and bounded live grounding validation.
+- Date: 2026-05-29
+- Objective: Add a bounded, repeatable validation path for the pilot S3/Postgres persistence baseline without adding infrastructure, deployment setup, migration redesign, or fake evidence.
 - Changes made:
-  - Updated the 2026-05-27 live grounding session note to record the successful rerun after the placeholder Exa API key was replaced.
-  - Reconciled roadmap and issue-tracker status so `#51` and `#56` are closed/completed instead of future follow-up work.
-  - Updated ADR-0002 and validation boundary docs to distinguish smoke validation from the bounded live CLI rerun.
-  - Kept the status sync docs-only; no app code, tests, frontend, persistence, deployment, or live Exa calls were changed or run during the sync.
+  - Added `scripts/run_pilot_persistence_validation.py` and `src/exa_demo/pilot_persistence_validation.py`.
+  - The command requires `PILOT_RUN_STORE=postgres`, `PILOT_POSTGRES_URL`, `PILOT_ARTIFACT_STORE=s3`, `PILOT_S3_BUCKET`, and a validation-scoped `PILOT_S3_PREFIX`.
+  - The command starts the FastAPI app unless `--base-url` is provided, runs one smoke `/api/search`, verifies `/health` reports `postgres` and `s3`, reads the matching run through `/api/me/runs`, verifies the persisted S3 artifact location/count, and lists the S3 prefix with `boto3`.
+  - Added focused tests for validation guardrails in `tests/test_persistence.py`.
+  - Updated `.env.example`, `docs/local-validation.md`, `docs/integration-boundaries.md`, `docs/roadmap.md`, `docs/issue-tracker.md`, and the session log.
 - Validation:
+  - `python -m ruff check src/exa_demo/pilot_persistence_validation.py scripts/run_pilot_persistence_validation.py tests/test_persistence.py` -> passed during implementation.
   - `python -m ruff check .` -> passed.
-  - `python -m pytest -q` -> passed (`299 passed`, one existing Jupyter path deprecation warning).
-  - `python scripts/run_live_validation.py --mode smoke` -> passed and wrote smoke artifacts under `live-validation-artifacts/`.
-  - `git diff --check` -> passed.
+  - `python -m pytest -q tests/test_persistence.py tests/test_api.py tests/test_api_auth.py` -> passed (`105 passed`).
+  - Real S3/Postgres validation was not run because required external config and credential hints were not present in the environment.
+- Open issues:
+  - Real external S3/Postgres validation was not claimed unless the command exits `0` against real services.
+  - The command exits `2` when required external persistence configuration is missing or still local-only.
+- Decisions proposed:
+  - Keep the path smoke-mode for Exa traffic and real for persistence.
+  - Keep the external command out of default CI because it requires Postgres, S3, and AWS credentials.
 
 ## Next thin slice
-- Continue Phase 5 Level 1 persistence work without widening into deployment or broad infra redesign.
+- Run the bounded validation command in a credentialed pilot environment and attach/review the JSON evidence.

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -32,7 +32,7 @@ Exa-powered insurance intelligence toolkit for CAT-loss, claims, expert, contrac
 Workflow engine plus controlled pilot web-product base for internal insurance-intelligence validation.
 
 ## Current milestone
-Phase 5 Level 1 is partially complete: the thin FastAPI wrapper, frontend shell, and pilot auth/request-boundary hardening are shipped, and the persistence baseline is in progress with additive S3/Postgres adapters plus API health self-reporting for selected persistence backends.
+Phase 5 Level 1 is partially complete: the thin FastAPI wrapper, frontend shell, and pilot auth/request-boundary hardening are shipped, and the persistence baseline is in progress with additive S3/Postgres adapters, API health self-reporting for selected persistence backends, and a bounded real-service S3/Postgres validation command.
 
 ## Durable decisions
 - Markdown docs under `docs/` remain the canonical backlog, architecture, ADR, and session-history surface for this repo.
@@ -45,12 +45,12 @@ Phase 5 Level 1 is partially complete: the thin FastAPI wrapper, frontend shell,
 Active Python workflow repo with package code in `src/exa_demo/`, a thin FastAPI app in the same package, and a Next.js frontend in `frontend/`. SQLite cache, budget controls, benchmark fixtures, exported artifacts, and smoke/live execution modes are already in place. Manual live validation is script-backed. The latest bounded live evidence covers only CLI `research` and `structured-search` grounding behavior; the broader local UI path remains smoke/mock.
 
 ## Top blockers
-- Phase 5 Level 1 is not complete because the persistence baseline still lacks end-to-end S3/Postgres-backed pilot validation and deployment posture; local defaults, pilot adapters, and backend self-reporting are present.
+- Phase 5 Level 1 is not complete because the persistence baseline still lacks actual external S3/Postgres-backed pilot evidence and deployment posture; local defaults, pilot adapters, backend self-reporting, and a bounded validation command are present.
 - GitHub issue numbering has drifted from the local Phase 5 roadmap IDs, so the tracker still has `TBD` GitHub URLs for those items until dedicated issues are created.
-- Broad live Exa behavior, S3/Postgres-backed runtime behavior, frontend live mode, and deployed pilot environments remain unvalidated. A bounded 2026-05-27 live CLI rerun did validate `research` and `structured-search` grounding behavior only.
+- Broad live Exa behavior, real S3/Postgres-backed runtime behavior, frontend live mode, and deployed pilot environments remain unvalidated unless the bounded validation command is run against real services. A bounded 2026-05-27 live CLI rerun did validate `research` and `structured-search` grounding behavior only.
 
 ## Docs freshness
-Workable. `README.md`, `docs/local-validation.md`, `docs/roadmap.md`, `docs/issue-tracker.md`, `docs/integration-boundaries.md`, and `docs/pilot-architecture-decision.md` reflect the current smoke/local, bounded live grounding, and persistence-in-progress posture; older March session notes remain historical and may describe pre-slice state.
+Workable. `README.md`, `docs/local-validation.md`, `docs/roadmap.md`, `docs/issue-tracker.md`, `docs/integration-boundaries.md`, and `docs/pilot-architecture-decision.md` reflect the current smoke/local, bounded live grounding, and persistence-in-progress posture with a real-service S3/Postgres validation command; older March session notes remain historical and may describe pre-slice state.
 
 ## Setup friction
 Moderate. Python setup is straightforward, but full local work spans Python deps, optional `[api]` extras, a separate `frontend/` npm install and env file, and deliberate handling of smoke versus live mode with `EXA_API_KEY` only for bounded manual validation.
@@ -59,6 +59,7 @@ Moderate. Python setup is straightforward, but full local work spans Python deps
 - `python -m ruff check .`
 - `python -m pytest -q`
 - `python scripts/run_live_validation.py --mode smoke`
+- `python scripts/run_pilot_persistence_validation.py --output live-validation-artifacts/pilot-s3-postgres-validation.json` only in an environment with real Postgres, S3, and AWS credentials
 - `uvicorn exa_demo.api:app --reload`
 - `cd frontend` then `npm install`, copy `.env.local.example` to `.env.local`, and run `npm run dev`
 
@@ -74,6 +75,7 @@ Moderate. Python setup is straightforward, but full local work spans Python deps
 - `docs/sessions/2026-03-22-api-wrapper.md`
 - `docs/sessions/2026-03-22-frontend-shell.md`
 - `scripts/run_live_validation.py`
+- `scripts/run_pilot_persistence_validation.py`
 - `scripts/run_notebook_smoke.py`
 
 ## Safe automation now

--- a/docs/integration-boundaries.md
+++ b/docs/integration-boundaries.md
@@ -30,6 +30,20 @@ This repo is designed to stay safe-by-default while still supporting deliberate 
 - Booted the Next.js frontend locally and verified Search, Answer, Research, and My Work against the local backend
 - Did **not** revalidate `live` mode, S3 artifact storage, or Postgres-backed usage/run persistence
 
+## Bounded S3/Postgres Persistence Validation
+
+Issue `#63` adds a narrow real-service validation command for the pilot persistence baseline:
+
+```powershell
+python scripts/run_pilot_persistence_validation.py --output live-validation-artifacts/pilot-s3-postgres-validation.json
+```
+
+This path is deliberately smoke-mode for Exa traffic, but real for persistence. It must run with `PILOT_RUN_STORE=postgres`, `PILOT_POSTGRES_URL`, `PILOT_ARTIFACT_STORE=s3`, `PILOT_S3_BUCKET`, and a validation-scoped `PILOT_S3_PREFIX`. AWS credentials must be available to `boto3` with upload/list access to the selected prefix. If API auth is enabled, `PILOT_VALIDATION_API_KEY` must contain a valid pilot API key.
+
+The command fails closed unless `/health` reports `run_store=postgres` and `artifact_store=s3`, one `/api/search` smoke request completes, the matching run is visible through `/api/me/runs`, the persisted `artifact_location` is the selected `s3://` prefix, and the S3 prefix lists at least the persisted artifact count.
+
+This command does not create infrastructure, deploy the app, redesign migrations, or prove live Exa behavior. Do not claim S3/Postgres validation passed unless this command exits `0` against real external Postgres and S3 services.
+
 ## Bounded Live Grounding Validation (2026-05-27)
 
 After replacing the placeholder Exa API key, a narrow live CLI rerun validated only `research` and `structured-search` grounding behavior:

--- a/docs/issue-tracker.md
+++ b/docs/issue-tracker.md
@@ -52,7 +52,7 @@ Issue `#11` originally used `/research` wording in the planning/demo sense. The 
 | `#20 Thin FastAPI wrapper over existing workflows` | Task | `Phase 5 - Pilot` | `type:task`, `area:api`, `priority:p0`, `status:done` | Done | `#19` | Phase 5 Level 1 | TBD | `docs/sessions/2026-03-22-api-wrapper.md` |
 | `#21 Frontend app shell (Next.js + Tailwind + shadcn/ui)` | Task | `Phase 5 - Pilot` | `type:task`, `area:frontend`, `priority:p0`, `status:done` | Done | `#19, #20` | Phase 5 Level 1 | TBD | `docs/sessions/2026-03-22-frontend-shell.md` |
 | `#22 Pilot auth + request/budget boundary controls` | Task | `Phase 5 - Pilot` | `type:task`, `area:auth`, `priority:p0`, `status:done` | Done | `#19, #20` | Phase 5 Level 1 | TBD | `docs/sessions/2026-04-11-issue-22-run-pagination-bounds.md` |
-| `#23 Persistence/state baseline (S3 artifacts + Postgres usage)` | Task | `Phase 5 - Pilot` | `type:task`, `area:infra`, `priority:p1`, `status:ready` | In progress | `#19, #20` | Phase 5 Level 1 | TBD | `docs/sessions/2026-04-28-issue-23-persistence-health-posture.md` |
+| `#23 Persistence/state baseline (S3 artifacts + Postgres usage)` | Task | `Phase 5 - Pilot` | `type:task`, `area:infra`, `priority:p1`, `status:ready` | In progress | `#19, #20` | Phase 5 Level 1 | TBD | `docs/sessions/2026-05-29-issue-63-s3-postgres-validation.md` |
 
 ### Next Coding Slices (Sequenced)
 
@@ -61,7 +61,7 @@ These are the immediate next implementation tasks, in recommended execution orde
 1. ~~**Slice 1: Thin API wrapper** (`#20`)~~ — Done. FastAPI app at `src/exa_demo/api.py` with 5 POST endpoints + health. 9 smoke-mode tests.
 2. ~~**Slice 2: Frontend app shell** (`#21`)~~ — Done. Next.js app in `frontend/` with search, answer, research panels. Server-side proxy to backend.
 3. ~~**Slice 3: Pilot auth + boundary controls** (`#22`)~~ — Done. Owner-or-ops record access, multi-user rate-limit isolation, saved-query input bounds, and run-pagination bounds are shipped.
-4. **Slice 4: Persistence baseline** (`#23`) - In progress. S3 artifact-location persistence, Postgres repository/factory coverage, backend factory logging, optional pilot dependency extras, and health backend labels are present; remaining work should continue tightening the pilot persistence baseline without widening into deployment or infra rollout.
+4. **Slice 4: Persistence baseline** (`#23`) - In progress. S3 artifact-location persistence, Postgres repository/factory coverage, backend factory logging, optional pilot dependency extras, health backend labels, and a bounded real S3/Postgres validation command/runbook are present; external S3/Postgres execution evidence still requires real services and credentials.
 
 Each slice should be one focused agent session. See [agent-execution-defaults.md](./agent-execution-defaults.md) for session rules.
 

--- a/docs/local-validation.md
+++ b/docs/local-validation.md
@@ -20,9 +20,68 @@ This runbook captures the repo's **current validated local state** as rechecked 
 
 - Live Exa mode (`--mode live`)
 - Real Exa API billing or live result quality
-- S3 artifact storage
-- Postgres-backed usage or run persistence
+- Real S3 artifact storage unless the bounded S3/Postgres command below is run
+- Real Postgres-backed usage or run persistence unless the bounded S3/Postgres command below is run
 - Production deployment, production readiness, or infrastructure rollout
+
+## Bounded S3/Postgres Pilot Persistence Validation
+
+This command is the repeatable issue `#63` path for real pilot persistence validation. It is intentionally not local SQLite evidence and not mock/fake S3 evidence.
+
+It runs one smoke-mode `/api/search` request through the FastAPI app, checks `/health` reports `run_store=postgres` and `artifact_store=s3`, reads the persisted run back through `/api/me/runs`, and lists the persisted S3 prefix with `boto3`. It exits without claiming success if the selected backends, required env vars, credentials, or services are missing.
+
+Required install:
+
+```powershell
+python -m pip install --no-user -e '.[pilot]'
+```
+
+Required services and credentials:
+
+- A reachable Postgres database in `PILOT_POSTGRES_URL`. The existing adapter creates the `runs` and `saved_queries` tables if they do not exist.
+- An existing S3 bucket in `PILOT_S3_BUCKET`.
+- AWS credentials available to `boto3` through the normal AWS chain, with permission to upload and list objects under `PILOT_S3_PREFIX`.
+- Optional API bearer auth. If auth is enabled, set `PILOT_VALIDATION_API_KEY` to a valid pilot user's API key; in single-key mode `PILOT_API_KEY` is also accepted by the script.
+
+Required environment variables:
+
+```powershell
+$env:PILOT_RUN_STORE = "postgres"
+$env:PILOT_POSTGRES_URL = "postgresql://USER:PASSWORD@HOST:5432/DBNAME"
+$env:PILOT_ARTIFACT_STORE = "s3"
+$env:PILOT_S3_BUCKET = "your-existing-validation-bucket"
+$env:PILOT_S3_PREFIX = "validation/pilot-persistence/"
+```
+
+Optional auth header source:
+
+```powershell
+$env:PILOT_VALIDATION_API_KEY = "pilot-user-api-key"
+```
+
+Run:
+
+```powershell
+python scripts/run_pilot_persistence_validation.py --output live-validation-artifacts/pilot-s3-postgres-validation.json
+```
+
+Expected success evidence:
+
+- JSON output with `status` set to `passed`
+- `health.run_store` is `postgres`
+- `health.artifact_store` is `s3`
+- `postgres_evidence.source` is `/api/me/runs`
+- `artifact_location` starts with `s3://<PILOT_S3_BUCKET>/<PILOT_S3_PREFIX>`
+- `artifact_count` is at least `1`
+- `s3_object_count` is at least the persisted `artifact_count`
+
+Exit codes:
+
+- `0`: real S3/Postgres validation passed
+- `1`: the command ran but validation failed
+- `2`: required external configuration was missing or still local-only
+
+Do not commit the JSON evidence file or generated runtime artifacts. `live-validation-artifacts/` and `experiments/` are local runtime output paths.
 
 ## Reproduce The Local Smoke Path
 
@@ -124,7 +183,7 @@ Open `http://localhost:3000`.
 - The validated path above is still **local + smoke/mock only**.
 - Do not treat this local UI smoke runbook as evidence that live Exa mode was revalidated.
 - A separate bounded live CLI grounding rerun on 2026-05-27 validated only `research` and `structured-search`; see [2026-05-27-live-grounding-validation.md](sessions/2026-05-27-live-grounding-validation.md).
-- Do not treat the current docs as evidence that S3 or Postgres-backed persistence was exercised end to end.
+- Do not treat the S3/Postgres command above as evidence unless it exits `0` against real external services and its JSON evidence is reviewed.
 - Treat deployment and production hardening as future work, not current state.
 
 ## Troubleshooting

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -138,14 +138,14 @@ See [pilot-architecture-decision.md](./pilot-architecture-decision.md) for the l
 
 Goal: a working web UI that internal users can use to run existing workflows through a browser instead of the CLI.
 
-Current local validation remains smoke/local only. Live Exa mode and S3/Postgres-backed runtime validation are still future work under the persistence baseline row below.
+Current local validation remains smoke/local only. Live Exa mode and real S3/Postgres-backed runtime validation still require explicit external-service runs; a bounded S3/Postgres validation command now exists for that path.
 
 | Roadmap item | Goal | Why it matters | Current status | Dependencies | Success criteria | GitHub issue |
 | --- | --- | --- | --- | --- | --- | --- |
 | Thin API wrapper | Expose existing workflows as FastAPI endpoints | Decouples frontend from Python CLI; enables web product path | `Done` | Phase 1-4 baseline | FastAPI app serves search, answer, research, find-similar, structured-search over HTTP with JSON responses | TBD |
 | Frontend app shell | Next.js + TypeScript + Tailwind + shadcn/ui scaffold with App Router | Establishes the frontend stack and deploy target | `Done` | Thin API wrapper | App shell renders, routes work, can call API endpoints | TBD |
 | Pilot auth + request boundary | Internal-only auth, request validation, rate limiting, budget guardrails, request logging | Prevents uncontrolled usage before the product is hardened | `Done` | Thin API wrapper | Only authenticated internal users can make requests; spend is bounded and logged | TBD |
-| Persistence baseline | Artifacts in S3, relational state/usage in Postgres, existing SQLite cache kept for local dev | Moves beyond local-only SQLite for pilot durability | `In progress` | Thin API wrapper | Target state: pilot runs persist artifacts to S3 and track usage in Postgres after explicit end-to-end validation; current API health output reports the selected run/artifact backends | TBD |
+| Persistence baseline | Artifacts in S3, relational state/usage in Postgres, existing SQLite cache kept for local dev | Moves beyond local-only SQLite for pilot durability | `In progress` | Thin API wrapper | Target state: pilot runs persist artifacts to S3 and track usage in Postgres after explicit end-to-end validation; current API health output reports selected run/artifact backends, and `scripts/run_pilot_persistence_validation.py` provides a bounded real-service validation command | TBD |
 
 ### Level 2 - Limited External Beta
 

--- a/docs/sessions/2026-05-29-issue-63-s3-postgres-validation.md
+++ b/docs/sessions/2026-05-29-issue-63-s3-postgres-validation.md
@@ -1,0 +1,48 @@
+# Session: Issue 63 S3/Postgres persistence validation
+
+- Date: 2026-05-29
+- Participants: Codex, user
+- Related GitHub issue: `#63`
+- Related roadmap items: local Phase 5 `#23`
+- Related ADRs: none
+
+## Context
+
+Add a bounded, repeatable validation path for the pilot persistence baseline without adding infrastructure, deployment setup, migration redesign, or fake S3/Postgres evidence.
+
+## Repo Facts Observed
+
+- `src/exa_demo/persistence.py` already has local/S3 artifact stores and local/Postgres run repositories.
+- `src/exa_demo/api.py` already reports selected persistence backend labels through `/health` and `/api/health`.
+- Existing tests cover adapter factories, fake Postgres behavior, S3 location formatting, API health labels, and auth boundaries.
+- Prior docs explicitly warned that S3/Postgres-backed runtime behavior had not been validated end to end.
+
+## Changes Made
+
+- Added `scripts/run_pilot_persistence_validation.py`, backed by `exa_demo.pilot_persistence_validation`, for one smoke-mode API workflow with real Postgres run metadata and real S3 artifact storage selected together.
+- The validation fails closed unless `PILOT_RUN_STORE=postgres`, `PILOT_ARTIFACT_STORE=s3`, `PILOT_POSTGRES_URL`, `PILOT_S3_BUCKET`, and a validation-scoped `PILOT_S3_PREFIX` are configured.
+- The validation checks `/health`, posts one `/api/search` request, reads the matching run through `/api/me/runs`, verifies the persisted `s3://` artifact location/count, and lists the S3 prefix with `boto3`.
+- Added focused guardrail tests for the validation config, health label, run matching, and S3 artifact-location checks.
+- Updated `.env.example`, local validation docs, integration boundaries, roadmap, and issue tracker wording to document the exact real-service command and avoid overclaiming external evidence.
+
+## Validation Run
+
+- `python -m ruff check src/exa_demo/pilot_persistence_validation.py scripts/run_pilot_persistence_validation.py tests/test_persistence.py` -> passed during implementation.
+- `python -m ruff check .` -> passed.
+- `python -m pytest -q tests/test_persistence.py tests/test_api.py tests/test_api_auth.py` -> passed (`105 passed`).
+- Real S3/Postgres validation command was not run because the environment did not have `PILOT_RUN_STORE`, `PILOT_POSTGRES_URL`, `PILOT_ARTIFACT_STORE`, `PILOT_S3_BUCKET`, `PILOT_S3_PREFIX`, or AWS credential env/profile hints configured.
+
+## Open Issues
+
+- Real external S3/Postgres validation requires actual Postgres, S3, and AWS credentials. They were unavailable in this session, so no external pass is claimed.
+- Local Phase 5 `#23` remains in progress until real S3/Postgres execution evidence is produced or the pilot persistence baseline is otherwise closed.
+
+## Decisions Proposed
+
+- Keep the validation command smoke-mode for Exa traffic but real for S3/Postgres persistence.
+- Keep the command out of CI by default because it requires external services and credentials.
+- Use `live-validation-artifacts/` for local JSON evidence output so runtime evidence is not committed.
+
+## Next Thin Slice
+
+- Run `python scripts/run_pilot_persistence_validation.py --output live-validation-artifacts/pilot-s3-postgres-validation.json` in an environment with the required external Postgres and S3 credentials, then record the actual evidence if it passes.

--- a/heartbeat.json
+++ b/heartbeat.json
@@ -1,9 +1,9 @@
 {
   "repo": "exai-insurance-intel",
-  "generated_at": "2026-05-27T20:11:07.891614+00:00",
+  "generated_at": "2026-05-29T23:40:31.112725+00:00",
   "purpose": "Exa-powered insurance intelligence toolkit for CAT-loss, claims, expert, contractor, and market/regulatory research workflows.",
   "strategic_role": "Workflow engine plus controlled pilot web-product base for internal insurance-intelligence validation.",
-  "current_milestone": "Phase 5 Level 1 is partially complete: the thin FastAPI wrapper, frontend shell, and pilot auth/request-boundary hardening are shipped, and the persistence baseline is in progress with additive S3/Postgres adapters plus API health self-reporting for selected persistence backends.",
+  "current_milestone": "Phase 5 Level 1 is partially complete: the thin FastAPI wrapper, frontend shell, and pilot auth/request-boundary hardening are shipped, and the persistence baseline is in progress with additive S3/Postgres adapters, API health self-reporting for selected persistence backends, and a bounded real-service S3/Postgres validation command.",
   "durable_decisions": [
     "Markdown docs under `docs/` remain the canonical backlog, architecture, ADR, and session-history surface for this repo.",
     "Existing CLI commands, artifact contracts, and smoke-first workflow expectations are stable and should be extended additively rather than rewritten.",
@@ -13,16 +13,17 @@
   ],
   "operating_posture": "Active Python workflow repo with package code in `src/exa_demo/`, a thin FastAPI app in the same package, and a Next.js frontend in `frontend/`. SQLite cache, budget controls, benchmark fixtures, exported artifacts, and smoke/live execution modes are already in place. Manual live validation is script-backed. The latest bounded live evidence covers only CLI `research` and `structured-search` grounding behavior; the broader local UI path remains smoke/mock.",
   "top_blockers": [
-    "Phase 5 Level 1 is not complete because the persistence baseline still lacks end-to-end S3/Postgres-backed pilot validation and deployment posture; local defaults, pilot adapters, and backend self-reporting are present.",
+    "Phase 5 Level 1 is not complete because the persistence baseline still lacks actual external S3/Postgres-backed pilot evidence and deployment posture; local defaults, pilot adapters, backend self-reporting, and a bounded validation command are present.",
     "GitHub issue numbering has drifted from the local Phase 5 roadmap IDs, so the tracker still has `TBD` GitHub URLs for those items until dedicated issues are created.",
-    "Broad live Exa behavior, S3/Postgres-backed runtime behavior, frontend live mode, and deployed pilot environments remain unvalidated. A bounded 2026-05-27 live CLI rerun did validate `research` and `structured-search` grounding behavior only."
+    "Broad live Exa behavior, real S3/Postgres-backed runtime behavior, frontend live mode, and deployed pilot environments remain unvalidated unless the bounded validation command is run against real services. A bounded 2026-05-27 live CLI rerun did validate `research` and `structured-search` grounding behavior only."
   ],
-  "docs_freshness": "Workable. `README.md`, `docs/local-validation.md`, `docs/roadmap.md`, `docs/issue-tracker.md`, `docs/integration-boundaries.md`, and `docs/pilot-architecture-decision.md` reflect the current smoke/local, bounded live grounding, and persistence-in-progress posture; older March session notes remain historical and may describe pre-slice state.",
+  "docs_freshness": "Workable. `README.md`, `docs/local-validation.md`, `docs/roadmap.md`, `docs/issue-tracker.md`, `docs/integration-boundaries.md`, and `docs/pilot-architecture-decision.md` reflect the current smoke/local, bounded live grounding, and persistence-in-progress posture with a real-service S3/Postgres validation command; older March session notes remain historical and may describe pre-slice state.",
   "setup_friction": "Moderate. Python setup is straightforward, but full local work spans Python deps, optional `[api]` extras, a separate `frontend/` npm install and env file, and deliberate handling of smoke versus live mode with `EXA_API_KEY` only for bounded manual validation.",
   "validation_path": [
     "`python -m ruff check .`",
     "`python -m pytest -q`",
     "`python scripts/run_live_validation.py --mode smoke`",
+    "`python scripts/run_pilot_persistence_validation.py --output live-validation-artifacts/pilot-s3-postgres-validation.json` only in an environment with real Postgres, S3, and AWS credentials",
     "`uvicorn exa_demo.api:app --reload`",
     "`cd frontend` then `npm install`, copy `.env.local.example` to `.env.local`, and run `npm run dev`"
   ],
@@ -38,6 +39,7 @@
     "`docs/sessions/2026-03-22-api-wrapper.md`",
     "`docs/sessions/2026-03-22-frontend-shell.md`",
     "`scripts/run_live_validation.py`",
+    "`scripts/run_pilot_persistence_validation.py`",
     "`scripts/run_notebook_smoke.py`"
   ],
   "safe_automation_now": [
@@ -52,27 +54,34 @@
   ],
   "update_policy": "`MEMORY.md` stays curated and human-reviewed. `memory/YYYY-MM-DD.md` stays append-only. `HEARTBEAT.md` and `heartbeat.json` are reproducible generated outputs and are never the durable source of truth.",
   "last_session": {
-    "date": "2026-05-27",
-    "objective": "Sync repo docs/status after the Exa 2026 modernization, cost-model reconciliation, and bounded live grounding validation.",
+    "date": "2026-05-29",
+    "objective": "Add a bounded, repeatable validation path for the pilot S3/Postgres persistence baseline without adding infrastructure, deployment setup, migration redesign, or fake evidence.",
     "changes_made": [
-      "Updated the 2026-05-27 live grounding session note to record the successful rerun after the placeholder Exa API key was replaced.",
-      "Reconciled roadmap and issue-tracker status so `#51` and `#56` are closed/completed instead of future follow-up work.",
-      "Updated ADR-0002 and validation boundary docs to distinguish smoke validation from the bounded live CLI rerun.",
-      "Kept the status sync docs-only; no app code, tests, frontend, persistence, deployment, or live Exa calls were changed or run during the sync."
+      "Added `scripts/run_pilot_persistence_validation.py` and `src/exa_demo/pilot_persistence_validation.py`.",
+      "The command requires `PILOT_RUN_STORE=postgres`, `PILOT_POSTGRES_URL`, `PILOT_ARTIFACT_STORE=s3`, `PILOT_S3_BUCKET`, and a validation-scoped `PILOT_S3_PREFIX`.",
+      "The command starts the FastAPI app unless `--base-url` is provided, runs one smoke `/api/search`, verifies `/health` reports `postgres` and `s3`, reads the matching run through `/api/me/runs`, verifies the persisted S3 artifact location/count, and lists the S3 prefix with `boto3`.",
+      "Added focused tests for validation guardrails in `tests/test_persistence.py`.",
+      "Updated `.env.example`, `docs/local-validation.md`, `docs/integration-boundaries.md`, `docs/roadmap.md`, `docs/issue-tracker.md`, and the session log."
     ],
     "validation_run": [
+      "`python -m ruff check src/exa_demo/pilot_persistence_validation.py scripts/run_pilot_persistence_validation.py tests/test_persistence.py` -> passed during implementation.",
       "`python -m ruff check .` -> passed.",
-      "`python -m pytest -q` -> passed (`299 passed`, one existing Jupyter path deprecation warning).",
-      "`python scripts/run_live_validation.py --mode smoke` -> passed and wrote smoke artifacts under `live-validation-artifacts/`.",
-      "`git diff --check` -> passed."
+      "`python -m pytest -q tests/test_persistence.py tests/test_api.py tests/test_api_auth.py` -> passed (`105 passed`).",
+      "Real S3/Postgres validation was not run because required external config and credential hints were not present in the environment."
     ],
-    "open_issues": [],
-    "decisions_proposed": [],
+    "open_issues": [
+      "Real external S3/Postgres validation was not claimed unless the command exits `0` against real services.",
+      "The command exits `2` when required external persistence configuration is missing or still local-only."
+    ],
+    "decisions_proposed": [
+      "Keep the path smoke-mode for Exa traffic and real for persistence.",
+      "Keep the external command out of default CI because it requires Postgres, S3, and AWS credentials."
+    ],
     "next_thin_slice": [
-      "Continue Phase 5 Level 1 persistence work without widening into deployment or broad infra redesign."
+      "Run the bounded validation command in a credentialed pilot environment and attach/review the JSON evidence."
     ]
   },
   "next_thin_slice": [
-    "Continue Phase 5 Level 1 persistence work without widening into deployment or broad infra redesign."
+    "Run the bounded validation command in a credentialed pilot environment and attach/review the JSON evidence."
   ]
 }

--- a/memory/2026-05-29.md
+++ b/memory/2026-05-29.md
@@ -1,0 +1,34 @@
+# Memory: Issue 63 S3/Postgres persistence validation path
+
+## Objective
+
+Add a bounded, repeatable validation path for the pilot S3/Postgres persistence baseline without adding infrastructure, deployment setup, migration redesign, or fake evidence.
+
+## Changes made
+
+- Added `scripts/run_pilot_persistence_validation.py` and `src/exa_demo/pilot_persistence_validation.py`.
+- The command requires `PILOT_RUN_STORE=postgres`, `PILOT_POSTGRES_URL`, `PILOT_ARTIFACT_STORE=s3`, `PILOT_S3_BUCKET`, and a validation-scoped `PILOT_S3_PREFIX`.
+- The command starts the FastAPI app unless `--base-url` is provided, runs one smoke `/api/search`, verifies `/health` reports `postgres` and `s3`, reads the matching run through `/api/me/runs`, verifies the persisted S3 artifact location/count, and lists the S3 prefix with `boto3`.
+- Added focused tests for validation guardrails in `tests/test_persistence.py`.
+- Updated `.env.example`, `docs/local-validation.md`, `docs/integration-boundaries.md`, `docs/roadmap.md`, `docs/issue-tracker.md`, and the session log.
+
+## Validation run
+
+- `python -m ruff check src/exa_demo/pilot_persistence_validation.py scripts/run_pilot_persistence_validation.py tests/test_persistence.py` -> passed during implementation.
+- `python -m ruff check .` -> passed.
+- `python -m pytest -q tests/test_persistence.py tests/test_api.py tests/test_api_auth.py` -> passed (`105 passed`).
+- Real S3/Postgres validation was not run because required external config and credential hints were not present in the environment.
+
+## Open issues
+
+- Real external S3/Postgres validation was not claimed unless the command exits `0` against real services.
+- The command exits `2` when required external persistence configuration is missing or still local-only.
+
+## Decisions proposed
+
+- Keep the path smoke-mode for Exa traffic and real for persistence.
+- Keep the external command out of default CI because it requires Postgres, S3, and AWS credentials.
+
+## Next thin slice
+
+- Run the bounded validation command in a credentialed pilot environment and attach/review the JSON evidence.

--- a/scripts/run_pilot_persistence_validation.py
+++ b/scripts/run_pilot_persistence_validation.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from exa_demo.pilot_persistence_validation import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/exa_demo/pilot_persistence_validation.py
+++ b/src/exa_demo/pilot_persistence_validation.py
@@ -1,0 +1,591 @@
+"""Bounded real S3/Postgres persistence validation for the pilot API."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+from urllib.parse import urlencode, urlparse
+
+
+REQUIRED_RUN_STORE = "postgres"
+REQUIRED_ARTIFACT_STORE = "s3"
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_TIMEOUT_SECONDS = 60.0
+DEFAULT_RESULT_LIMIT = 25
+DEFAULT_VALIDATION_PREFIX = "validation/pilot-persistence/"
+
+SECRET_ENV_NAMES = (
+    "PILOT_POSTGRES_URL",
+    "PILOT_API_KEY",
+    "PILOT_VALIDATION_API_KEY",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+    "EXA_API_KEY",
+)
+
+
+class PersistenceValidationError(RuntimeError):
+    """Raised when real persistence validation cannot pass."""
+
+
+class PersistenceValidationConfigError(PersistenceValidationError):
+    """Raised when required external validation configuration is absent."""
+
+
+@dataclass(frozen=True)
+class ValidationConfig:
+    """Runtime options for the bounded API validation."""
+
+    repo_root: Path
+    base_url: str | None
+    host: str
+    port: int | None
+    timeout_seconds: float
+    query: str
+    run_id: str
+    api_key: str | None
+    output_path: Path | None
+    result_limit: int = DEFAULT_RESULT_LIMIT
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run one smoke API workflow with PILOT_RUN_STORE=postgres and "
+            "PILOT_ARTIFACT_STORE=s3 selected, then verify persisted run "
+            "metadata and S3 artifact evidence."
+        )
+    )
+    parser.add_argument(
+        "--base-url",
+        help=(
+            "Use an already-running API instead of starting uvicorn. "
+            "The API must already be configured for postgres/s3."
+        ),
+    )
+    parser.add_argument("--host", default=DEFAULT_HOST)
+    parser.add_argument(
+        "--port",
+        type=int,
+        help="Port for the temporary uvicorn process. Defaults to a free port.",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=DEFAULT_TIMEOUT_SECONDS,
+        help="Seconds to wait for API startup and persisted run visibility.",
+    )
+    parser.add_argument(
+        "--query",
+        help="Optional validation query marker. Defaults to a UTC timestamp.",
+    )
+    parser.add_argument(
+        "--run-id",
+        help=(
+            "Run id to inject into the temporary API process. Ignored when "
+            "--base-url is used with an already-running API."
+        ),
+    )
+    parser.add_argument(
+        "--api-key-env",
+        default="PILOT_VALIDATION_API_KEY",
+        help=(
+            "Environment variable containing the bearer token to send. "
+            "Falls back to PILOT_API_KEY when this variable is unset."
+        ),
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path for the JSON evidence summary.",
+    )
+    parser.add_argument(
+        "--result-limit",
+        type=int,
+        default=DEFAULT_RESULT_LIMIT,
+        help="Number of recent /api/me/runs records to inspect.",
+    )
+    return parser.parse_args(argv)
+
+
+def config_from_args(
+    args: argparse.Namespace,
+    *,
+    repo_root: Path | None = None,
+    env: Mapping[str, str] | None = None,
+) -> ValidationConfig:
+    env = env or os.environ
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    run_id = args.run_id or f"pilot-persistence-{timestamp}"
+    query = args.query or f"Pilot S3/Postgres validation {run_id}"
+    api_key = (
+        env.get(args.api_key_env, "").strip()
+        or env.get("PILOT_API_KEY", "").strip()
+        or None
+    )
+    return ValidationConfig(
+        repo_root=(repo_root or Path.cwd()).resolve(),
+        base_url=_normalize_base_url(args.base_url),
+        host=args.host,
+        port=args.port,
+        timeout_seconds=args.timeout,
+        query=query,
+        run_id=run_id,
+        api_key=api_key,
+        output_path=args.output,
+        result_limit=args.result_limit,
+    )
+
+
+def required_external_config_errors(env: Mapping[str, str]) -> list[str]:
+    """Return missing/mismatched config that would make validation ambiguous."""
+
+    errors: list[str] = []
+    run_store = env.get("PILOT_RUN_STORE", "").strip().lower()
+    if run_store != REQUIRED_RUN_STORE:
+        errors.append("PILOT_RUN_STORE must be set to postgres.")
+
+    artifact_store = env.get("PILOT_ARTIFACT_STORE", "").strip().lower()
+    if artifact_store != REQUIRED_ARTIFACT_STORE:
+        errors.append("PILOT_ARTIFACT_STORE must be set to s3.")
+
+    if not env.get("PILOT_POSTGRES_URL", "").strip():
+        errors.append("PILOT_POSTGRES_URL must point to a reachable Postgres DB.")
+
+    if not env.get("PILOT_S3_BUCKET", "").strip():
+        errors.append("PILOT_S3_BUCKET must name the validation S3 bucket.")
+
+    if not env.get("PILOT_S3_PREFIX", "").strip():
+        errors.append(
+            "PILOT_S3_PREFIX must be set to a validation-scoped prefix, "
+            f"for example {DEFAULT_VALIDATION_PREFIX}."
+        )
+
+    return errors
+
+
+def run_validation(
+    config: ValidationConfig,
+    *,
+    env: Mapping[str, str] | None = None,
+) -> dict[str, Any]:
+    env = dict(env or os.environ)
+    config_errors = required_external_config_errors(env)
+    if config_errors:
+        joined = "\n".join(f"- {error}" for error in config_errors)
+        raise PersistenceValidationConfigError(
+            "Real S3/Postgres validation was not run because required "
+            f"configuration is missing or local-only:\n{joined}"
+        )
+
+    if config.base_url:
+        return _run_against_api(config.base_url, config, env=env)
+
+    port = config.port or _find_free_port(config.host)
+    base_url = f"http://{config.host}:{port}"
+    process = _start_api_process(config, port=port, env=env)
+    try:
+        _wait_for_health(
+            base_url,
+            timeout_seconds=config.timeout_seconds,
+            process=process,
+            env=env,
+        )
+        return _run_against_api(base_url, config, env=env)
+    finally:
+        _stop_process(process)
+
+
+def _run_against_api(
+    base_url: str,
+    config: ValidationConfig,
+    *,
+    env: Mapping[str, str],
+) -> dict[str, Any]:
+    headers = _auth_headers(config.api_key)
+    health = _request_json("GET", f"{base_url}/health", headers=headers)
+    validate_external_health(health)
+
+    search_payload = {
+        "query": config.query,
+        "mode": "smoke",
+        "num_results": 1,
+    }
+    search_result = _request_json(
+        "POST",
+        f"{base_url}/api/search",
+        payload=search_payload,
+        headers=headers,
+    )
+    api_run_id = str(search_result.get("run_id") or "").strip()
+    if not api_run_id:
+        raise PersistenceValidationError("API search response did not include run_id.")
+
+    record = _wait_for_matching_run(
+        base_url,
+        config=config,
+        api_run_id=api_run_id,
+        headers=headers,
+    )
+    artifact_location = validate_persisted_record(
+        record,
+        bucket=env["PILOT_S3_BUCKET"].strip(),
+        prefix=env["PILOT_S3_PREFIX"].strip(),
+        api_run_id=api_run_id,
+        query=config.query,
+    )
+    s3_object_count = count_s3_objects(artifact_location)
+    artifact_count = int(record.get("artifact_count") or 0)
+    if s3_object_count < artifact_count:
+        raise PersistenceValidationError(
+            "S3 object count is lower than the persisted artifact_count "
+            f"({s3_object_count} < {artifact_count})."
+        )
+
+    return {
+        "validation": "pilot-s3-postgres-persistence",
+        "status": "passed",
+        "mode": "smoke",
+        "health": health,
+        "query_marker": config.query,
+        "api_run_id": api_run_id,
+        "run_record_id": record.get("id"),
+        "run_record_user_id": record.get("user_id"),
+        "artifact_location": artifact_location,
+        "artifact_count": artifact_count,
+        "s3_object_count": s3_object_count,
+        "postgres_evidence": {
+            "source": "/api/me/runs",
+            "run_store": health.get("run_store"),
+            "record_status": record.get("status"),
+        },
+        "s3_evidence": {
+            "bucket": env["PILOT_S3_BUCKET"].strip(),
+            "prefix": _s3_prefix_from_location(artifact_location),
+            "artifact_store": health.get("artifact_store"),
+        },
+    }
+
+
+def validate_external_health(health: Mapping[str, Any]) -> None:
+    if health.get("status") != "ok":
+        raise PersistenceValidationError(f"Unexpected health status: {health!r}")
+    if health.get("run_store") != REQUIRED_RUN_STORE:
+        raise PersistenceValidationError(
+            "API health did not report run_store=postgres; "
+            f"got {health.get('run_store')!r}."
+        )
+    if health.get("artifact_store") != REQUIRED_ARTIFACT_STORE:
+        raise PersistenceValidationError(
+            "API health did not report artifact_store=s3; "
+            f"got {health.get('artifact_store')!r}."
+        )
+
+
+def find_matching_run(
+    runs_payload: Mapping[str, Any],
+    *,
+    query: str,
+    api_run_id: str,
+) -> Mapping[str, Any] | None:
+    runs = runs_payload.get("runs")
+    if not isinstance(runs, list):
+        raise PersistenceValidationError("/api/me/runs response did not include runs.")
+
+    for item in runs:
+        if not isinstance(item, Mapping):
+            continue
+        if item.get("run_id") == api_run_id and item.get("query_preview") == query:
+            return item
+    return None
+
+
+def validate_persisted_record(
+    record: Mapping[str, Any],
+    *,
+    bucket: str,
+    prefix: str,
+    api_run_id: str,
+    query: str,
+) -> str:
+    if record.get("workflow") != "search":
+        raise PersistenceValidationError("Persisted run workflow was not search.")
+    if record.get("mode") != "smoke":
+        raise PersistenceValidationError("Persisted run mode was not smoke.")
+    if record.get("status") != "completed":
+        raise PersistenceValidationError("Persisted run did not complete.")
+    if record.get("query_preview") != query:
+        raise PersistenceValidationError("Persisted run query marker did not match.")
+
+    artifact_count = int(record.get("artifact_count") or 0)
+    if artifact_count < 1:
+        raise PersistenceValidationError(
+            "Persisted run did not record uploaded artifacts."
+        )
+
+    artifact_location = str(record.get("artifact_location") or "").strip()
+    expected = expected_s3_location(
+        bucket=bucket,
+        prefix=prefix,
+        api_run_id=api_run_id,
+    )
+    if artifact_location != expected:
+        raise PersistenceValidationError(
+            "Persisted artifact_location did not match the selected S3 store "
+            f"({artifact_location!r} != {expected!r})."
+        )
+    return artifact_location
+
+
+def expected_s3_location(*, bucket: str, prefix: str, api_run_id: str) -> str:
+    normalized_prefix = prefix.strip().rstrip("/") + "/"
+    return f"s3://{bucket.strip()}/{normalized_prefix}{api_run_id}/"
+
+
+def count_s3_objects(artifact_location: str) -> int:
+    parsed = urlparse(artifact_location)
+    if parsed.scheme != "s3" or not parsed.netloc or not parsed.path.strip("/"):
+        raise PersistenceValidationError(
+            f"Invalid S3 artifact location: {artifact_location!r}"
+        )
+
+    import boto3  # type: ignore[import-untyped]
+
+    prefix = parsed.path.lstrip("/")
+    response = boto3.client("s3").list_objects_v2(
+        Bucket=parsed.netloc,
+        Prefix=prefix,
+    )
+    return len(response.get("Contents", []))
+
+
+def _wait_for_matching_run(
+    base_url: str,
+    *,
+    config: ValidationConfig,
+    api_run_id: str,
+    headers: Mapping[str, str],
+) -> Mapping[str, Any]:
+    deadline = time.monotonic() + config.timeout_seconds
+    params = urlencode(
+        {
+            "workflow": "search",
+            "status": "completed",
+            "limit": str(config.result_limit),
+            "offset": "0",
+        }
+    )
+    url = f"{base_url}/api/me/runs?{params}"
+    last_payload: Mapping[str, Any] | None = None
+
+    while time.monotonic() < deadline:
+        payload = _request_json("GET", url, headers=headers)
+        last_payload = payload
+        record = find_matching_run(
+            payload,
+            query=config.query,
+            api_run_id=api_run_id,
+        )
+        if record is not None:
+            return record
+        time.sleep(0.5)
+
+    raise PersistenceValidationError(
+        "Timed out waiting for the API to expose the persisted run through "
+        f"/api/me/runs. Last response: {last_payload!r}"
+    )
+
+
+def _request_json(
+    method: str,
+    url: str,
+    *,
+    payload: Mapping[str, Any] | None = None,
+    headers: Mapping[str, str] | None = None,
+    timeout: float = 15.0,
+) -> dict[str, Any]:
+    body = None
+    request_headers = {"Accept": "application/json"}
+    if headers:
+        request_headers.update(headers)
+    if payload is not None:
+        body = json.dumps(payload).encode("utf-8")
+        request_headers["Content-Type"] = "application/json"
+
+    request = urllib.request.Request(
+        url,
+        data=body,
+        headers=request_headers,
+        method=method,
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            raw = response.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        raw_error = exc.read().decode("utf-8", errors="replace")
+        raise PersistenceValidationError(
+            f"HTTP {exc.code} from {method} {url}: {raw_error}"
+        ) from exc
+    except urllib.error.URLError as exc:
+        raise PersistenceValidationError(
+            f"Could not reach API at {url}: {exc.reason}"
+        ) from exc
+
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise PersistenceValidationError(
+            f"API response was not JSON for {method} {url}: {raw!r}"
+        ) from exc
+    if not isinstance(parsed, dict):
+        raise PersistenceValidationError(
+            f"API response was not a JSON object for {method} {url}."
+        )
+    return parsed
+
+
+def _wait_for_health(
+    base_url: str,
+    *,
+    timeout_seconds: float,
+    process: subprocess.Popen[str],
+    env: Mapping[str, str],
+) -> None:
+    deadline = time.monotonic() + timeout_seconds
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            output = _process_output(process, env)
+            raise PersistenceValidationError(
+                "API process exited before health check passed "
+                f"(exit {process.returncode}). {output}"
+            )
+        try:
+            _request_json("GET", f"{base_url}/health", timeout=2.0)
+            return
+        except PersistenceValidationError as exc:
+            last_error = exc
+            time.sleep(0.5)
+    raise PersistenceValidationError(
+        f"Timed out waiting for API health at {base_url}/health. "
+        f"Last error: {last_error}"
+    )
+
+
+def _start_api_process(
+    config: ValidationConfig,
+    *,
+    port: int,
+    env: Mapping[str, str],
+) -> subprocess.Popen[str]:
+    process_env = dict(env)
+    process_env["EXA_SMOKE_NO_NETWORK"] = "1"
+    process_env["EXA_RUN_ID"] = config.run_id
+    argv = [
+        sys.executable,
+        "-m",
+        "uvicorn",
+        "exa_demo.api:app",
+        "--host",
+        config.host,
+        "--port",
+        str(port),
+        "--log-level",
+        "warning",
+    ]
+    return subprocess.Popen(
+        argv,
+        cwd=config.repo_root,
+        env=process_env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def _process_output(
+    process: subprocess.Popen[str],
+    env: Mapping[str, str],
+) -> str:
+    stdout, stderr = process.communicate(timeout=2)
+    pieces = []
+    if stdout:
+        pieces.append(f"stdout={_sanitize_output(stdout, env)}")
+    if stderr:
+        pieces.append(f"stderr={_sanitize_output(stderr, env)}")
+    return " ".join(pieces)
+
+
+def _sanitize_output(text: str, env: Mapping[str, str]) -> str:
+    sanitized = text[-4000:]
+    for name in SECRET_ENV_NAMES:
+        value = env.get(name, "").strip()
+        if len(value) >= 4:
+            sanitized = sanitized.replace(value, f"<redacted:{name}>")
+    return sanitized
+
+
+def _stop_process(process: subprocess.Popen[str]) -> None:
+    if process.poll() is not None:
+        return
+    process.terminate()
+    try:
+        process.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=5)
+
+
+def _find_free_port(host: str) -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind((host, 0))
+        return int(sock.getsockname()[1])
+
+
+def _auth_headers(api_key: str | None) -> dict[str, str]:
+    if not api_key:
+        return {}
+    return {"Authorization": f"Bearer {api_key}"}
+
+
+def _normalize_base_url(base_url: str | None) -> str | None:
+    if not base_url:
+        return None
+    return base_url.rstrip("/")
+
+
+def _s3_prefix_from_location(artifact_location: str) -> str:
+    parsed = urlparse(artifact_location)
+    return parsed.path.lstrip("/")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    config = config_from_args(args)
+    try:
+        result = run_validation(config)
+    except PersistenceValidationConfigError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    except Exception as exc:
+        print(f"Pilot persistence validation failed: {exc}", file=sys.stderr)
+        return 1
+
+    output = json.dumps(result, indent=2, sort_keys=True)
+    print(output)
+    if config.output_path is not None:
+        config.output_path.parent.mkdir(parents=True, exist_ok=True)
+        config.output_path.write_text(output + "\n", encoding="utf-8")
+    return 0

--- a/src/exa_demo/pilot_persistence_validation.py
+++ b/src/exa_demo/pilot_persistence_validation.py
@@ -6,7 +6,7 @@ import argparse
 import json
 import os
 import socket
-import subprocess
+import subprocess  # nosec B404
 import sys
 import time
 import urllib.error
@@ -24,6 +24,10 @@ DEFAULT_HOST = "127.0.0.1"
 DEFAULT_TIMEOUT_SECONDS = 60.0
 DEFAULT_RESULT_LIMIT = 25
 DEFAULT_VALIDATION_PREFIX = "validation/pilot-persistence/"
+# Validation runs must write under this top-level prefix segment so the bounded
+# smoke run can never land in a shared/production artifact namespace such as
+# the ``artifacts/`` default used by ``create_artifact_store``.
+VALIDATION_PREFIX_ROOT = "validation"
 
 SECRET_ENV_NAMES = (
     "PILOT_POSTGRES_URL",
@@ -149,6 +153,21 @@ def config_from_args(
     )
 
 
+def is_validation_scoped_prefix(prefix: str) -> bool:
+    """Return True only when ``prefix`` is under the validation root segment.
+
+    A validation-scoped prefix has ``validation`` as its first path segment
+    (e.g. ``validation/pilot-persistence/``). Shared persistence prefixes such
+    as ``artifacts/`` — the default used by ``create_artifact_store`` — are
+    rejected so the bounded smoke run cannot pollute a non-validation namespace.
+    """
+
+    normalized = prefix.strip().strip("/")
+    if not normalized:
+        return False
+    return normalized.split("/", 1)[0] == VALIDATION_PREFIX_ROOT
+
+
 def required_external_config_errors(env: Mapping[str, str]) -> list[str]:
     """Return missing/mismatched config that would make validation ambiguous."""
 
@@ -167,10 +186,19 @@ def required_external_config_errors(env: Mapping[str, str]) -> list[str]:
     if not env.get("PILOT_S3_BUCKET", "").strip():
         errors.append("PILOT_S3_BUCKET must name the validation S3 bucket.")
 
-    if not env.get("PILOT_S3_PREFIX", "").strip():
+    s3_prefix = env.get("PILOT_S3_PREFIX", "").strip()
+    if not s3_prefix:
         errors.append(
             "PILOT_S3_PREFIX must be set to a validation-scoped prefix, "
             f"for example {DEFAULT_VALIDATION_PREFIX}."
+        )
+    elif not is_validation_scoped_prefix(s3_prefix):
+        errors.append(
+            "PILOT_S3_PREFIX must be a validation-scoped prefix under "
+            f"'{VALIDATION_PREFIX_ROOT}/' (for example "
+            f"{DEFAULT_VALIDATION_PREFIX}); refusing to run the validation "
+            "smoke write into a shared artifact namespace such as 'artifacts/'. "
+            f"Got {s3_prefix!r}."
         )
 
     return errors
@@ -431,7 +459,9 @@ def _request_json(
         method=method,
     )
     try:
-        with urllib.request.urlopen(request, timeout=timeout) as response:
+        # base_url is either an internal http://127.0.0.1:<port> address or an
+        # operator-supplied --base-url; only http(s) validation traffic is sent.
+        with urllib.request.urlopen(request, timeout=timeout) as response:  # nosec B310
             raw = response.read().decode("utf-8")
     except urllib.error.HTTPError as exc:
         raw_error = exc.read().decode("utf-8", errors="replace")
@@ -505,7 +535,9 @@ def _start_api_process(
         "--log-level",
         "warning",
     ]
-    return subprocess.Popen(
+    # argv is a fixed list (python -m uvicorn ...) with no shell and no
+    # untrusted interpolation; host defaults to loopback and port is an int.
+    return subprocess.Popen(  # nosec B603
         argv,
         cwd=config.repo_root,
         env=process_env,

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1032,6 +1032,32 @@ class TestPilotPersistenceValidation:
 
         assert errors == []
 
+    def test_required_external_config_errors_rejects_unsafe_prefix(self):
+        errors = validation_module.required_external_config_errors(
+            {
+                "PILOT_RUN_STORE": "postgres",
+                "PILOT_POSTGRES_URL": "postgresql://user:pass@db/pilot",
+                "PILOT_ARTIFACT_STORE": "s3",
+                "PILOT_S3_BUCKET": "pilot-validation",
+                # Shared/production prefix (create_artifact_store default).
+                "PILOT_S3_PREFIX": "artifacts/",
+            }
+        )
+
+        assert any("PILOT_S3_PREFIX" in error for error in errors)
+        assert any("artifacts/" in error for error in errors)
+
+    def test_is_validation_scoped_prefix(self):
+        assert validation_module.is_validation_scoped_prefix(
+            "validation/pilot-persistence/"
+        )
+        assert validation_module.is_validation_scoped_prefix("validation/")
+        assert validation_module.is_validation_scoped_prefix("/validation/x/")
+        assert not validation_module.is_validation_scoped_prefix("artifacts/")
+        assert not validation_module.is_validation_scoped_prefix("")
+        # Must match the exact path segment, not a prefix string.
+        assert not validation_module.is_validation_scoped_prefix("validations/x/")
+
     def test_validate_external_health_rejects_local_backends(self):
         with pytest.raises(
             validation_module.PersistenceValidationError,

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import exa_demo.api as api_module
+import exa_demo.pilot_persistence_validation as validation_module
 import exa_demo.persistence as persist_module
 import pytest
 from fastapi.testclient import TestClient
@@ -1001,6 +1002,127 @@ class TestFactories:
         monkeypatch.delenv("PILOT_POSTGRES_URL", raising=False)
         with pytest.raises(RuntimeError, match="PILOT_POSTGRES_URL"):
             persist_module.create_run_repository()
+
+
+# ---------------------------------------------------------------------------
+# Bounded real S3/Postgres validation guardrails
+# ---------------------------------------------------------------------------
+
+
+class TestPilotPersistenceValidation:
+    def test_required_external_config_errors_rejects_local_defaults(self):
+        errors = validation_module.required_external_config_errors({})
+
+        assert "PILOT_RUN_STORE must be set to postgres." in errors
+        assert "PILOT_ARTIFACT_STORE must be set to s3." in errors
+        assert any("PILOT_POSTGRES_URL" in error for error in errors)
+        assert any("PILOT_S3_BUCKET" in error for error in errors)
+        assert any("PILOT_S3_PREFIX" in error for error in errors)
+
+    def test_required_external_config_errors_accepts_real_selection(self):
+        errors = validation_module.required_external_config_errors(
+            {
+                "PILOT_RUN_STORE": "postgres",
+                "PILOT_POSTGRES_URL": "postgresql://user:pass@db/pilot",
+                "PILOT_ARTIFACT_STORE": "s3",
+                "PILOT_S3_BUCKET": "pilot-validation",
+                "PILOT_S3_PREFIX": "validation/pilot-persistence/",
+            }
+        )
+
+        assert errors == []
+
+    def test_validate_external_health_rejects_local_backends(self):
+        with pytest.raises(
+            validation_module.PersistenceValidationError,
+            match="run_store=postgres",
+        ):
+            validation_module.validate_external_health(
+                {
+                    "status": "ok",
+                    "run_store": "local",
+                    "artifact_store": "s3",
+                }
+            )
+
+        with pytest.raises(
+            validation_module.PersistenceValidationError,
+            match="artifact_store=s3",
+        ):
+            validation_module.validate_external_health(
+                {
+                    "status": "ok",
+                    "run_store": "postgres",
+                    "artifact_store": "local",
+                }
+            )
+
+    def test_find_matching_run_uses_query_marker_and_run_id(self):
+        payload = {
+            "runs": [
+                {
+                    "id": "wrong-query",
+                    "run_id": "run-1",
+                    "query_preview": "other query",
+                },
+                {
+                    "id": "matched",
+                    "run_id": "run-1",
+                    "query_preview": "Pilot validation marker",
+                },
+            ]
+        }
+
+        record = validation_module.find_matching_run(
+            payload,
+            query="Pilot validation marker",
+            api_run_id="run-1",
+        )
+
+        assert record is not None
+        assert record["id"] == "matched"
+
+    def test_validate_persisted_record_requires_s3_location(self):
+        record = {
+            "workflow": "search",
+            "mode": "smoke",
+            "status": "completed",
+            "query_preview": "Pilot validation marker",
+            "artifact_count": 3,
+            "artifact_location": "s3://pilot-validation/validation/pilot-persistence/run-1/",
+        }
+
+        location = validation_module.validate_persisted_record(
+            record,
+            bucket="pilot-validation",
+            prefix="validation/pilot-persistence/",
+            api_run_id="run-1",
+            query="Pilot validation marker",
+        )
+
+        assert location == "s3://pilot-validation/validation/pilot-persistence/run-1/"
+
+    def test_validate_persisted_record_rejects_missing_artifacts(self):
+        record = {
+            "workflow": "search",
+            "mode": "smoke",
+            "status": "completed",
+            "query_preview": "Pilot validation marker",
+            "artifact_count": 0,
+            "artifact_location": None,
+        }
+
+        with pytest.raises(
+            validation_module.PersistenceValidationError,
+            match="uploaded artifacts",
+        ):
+            validation_module.validate_persisted_record(
+                record,
+                bucket="pilot-validation",
+                prefix="validation/pilot-persistence/",
+                api_run_id="run-1",
+                query="Pilot validation marker",
+            )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #63

## Summary
- Adds `scripts/run_pilot_persistence_validation.py` backed by `exa_demo.pilot_persistence_validation`.
- The command fails closed unless `PILOT_RUN_STORE=postgres`, `PILOT_ARTIFACT_STORE=s3`, `PILOT_POSTGRES_URL`, `PILOT_S3_BUCKET`, and a validation-scoped `PILOT_S3_PREFIX` are configured.
- The validation checks `/health`, runs one smoke-mode `/api/search`, reads the matching run through `/api/me/runs`, verifies the persisted `s3://` artifact location/count, and lists the S3 prefix with `boto3`.
- Updates local validation and integration-boundary docs without claiming external S3/Postgres success.

## Validation
- `python -m ruff check .` -> passed.
- `python -m pytest -q tests/test_persistence.py tests/test_api.py tests/test_api_auth.py` -> passed (`105 passed`).
- Real S3/Postgres validation was not run because the environment did not have the required `PILOT_*` settings or AWS credential/profile hints configured.

## Boundaries respected
- No infrastructure, deployment setup, migration redesign, persistence redesign, or auth behavior changes.
- The validation path is smoke-mode for Exa traffic and real-service only for S3/Postgres persistence.
- No runtime artifacts, secrets, or fake external evidence are committed.