### PR TITLE
Issue #64: Add fail-closed auth guard for pilot deployment mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,14 @@ EXA_API_KEY=your_exa_api_key_here
 # Optional: set to 1 to run local smoke tests without network/API billing.
 EXA_SMOKE_NO_NETWORK=0
 
+# Optional pilot API auth configuration.
+# Local smoke can omit these values. Set PILOT_REQUIRE_AUTH=1 for pilot or
+# deployment-style runtime so /api routes fail closed unless auth is configured.
+# PILOT_REQUIRE_AUTH=0
+# PILOT_API_KEY=your_pilot_api_key_here
+# PILOT_USERS={"alice":"alice_api_key","ops":"ops_api_key"}
+# PILOT_OPS_USERS=ops
+
 # Optional pilot persistence configuration.
 # Keep the defaults for local dev, or switch to postgres/s3 for the pilot path.
 # PILOT_RUN_STORE=local

--- a/docs/security.md
+++ b/docs/security.md
@@ -52,6 +52,12 @@ Install with: `pre-commit install`
 - Set `PILOT_REQUIRE_AUTH=1` for pilot/deployment runtime so authenticated
   `/api` routes fail closed if neither `PILOT_API_KEY` nor valid `PILOT_USERS`
   is configured
+- "Valid `PILOT_USERS`" means at least one non-empty string secret. Values such
+  as `null`, empty/whitespace-only strings, objects, arrays, booleans, or
+  numbers are ignored and do not count as configured auth
+- The fail-closed response is `503` (service unavailable), signalling a
+  deployment/server-side auth **misconfiguration** — not a normal per-request
+  user auth failure, which remains `401`
 - Sliding-window rate limiting (default 60 req/min, returns 429). Multi-user mode isolates buckets per authenticated user; single-key and no-auth modes fall back to per-IP limiting.
 - Ops user allowlist for admin endpoints
 - Live mode gated behind `PILOT_ALLOW_LIVE_MODE=1`

--- a/docs/security.md
+++ b/docs/security.md
@@ -47,6 +47,11 @@ Install with: `pre-commit install`
 
 ### API Authentication (`api_auth.py`)
 - Bearer token validation (multi-user or single shared key)
+- Local smoke/no-auth behavior remains available only when neither
+  `PILOT_API_KEY` nor `PILOT_USERS` is set and `PILOT_REQUIRE_AUTH` is not `1`
+- Set `PILOT_REQUIRE_AUTH=1` for pilot/deployment runtime so authenticated
+  `/api` routes fail closed if neither `PILOT_API_KEY` nor valid `PILOT_USERS`
+  is configured
 - Sliding-window rate limiting (default 60 req/min, returns 429). Multi-user mode isolates buckets per authenticated user; single-key and no-auth modes fall back to per-IP limiting.
 - Ops user allowlist for admin endpoints
 - Live mode gated behind `PILOT_ALLOW_LIVE_MODE=1`

--- a/src/exa_demo/api_auth.py
+++ b/src/exa_demo/api_auth.py
@@ -2,10 +2,14 @@
 
 Configuration via environment variables:
 
-    PILOT_API_KEY              Shared secret for bearer auth. If unset, auth is disabled.
+    PILOT_API_KEY              Shared secret for bearer auth. If unset, auth is disabled
+                               unless PILOT_REQUIRE_AUTH=1.
     PILOT_USERS                JSON mapping of user_id → api_key for multi-user mode.
                                Example: {"alice": "key-alice", "bob": "key-bob"}
                                Takes precedence over PILOT_API_KEY when set.
+    PILOT_REQUIRE_AUTH         Set to "1" for pilot/deployment runtime; API routes
+                               fail closed unless PILOT_API_KEY or valid PILOT_USERS
+                               is configured.
     PILOT_OPS_USERS            Comma-separated user_ids allowed to access ops/admin
                                surfaces like /api/runs and /api/ops/summary.
                                Defaults to "pilot".
@@ -43,6 +47,10 @@ DEFAULT_USER_ID = "pilot"
 
 def _pilot_api_key() -> str:
     return os.environ.get("PILOT_API_KEY", "").strip()
+
+
+def _pilot_require_auth() -> bool:
+    return os.environ.get("PILOT_REQUIRE_AUTH", "0").strip() == "1"
 
 
 def _pilot_users() -> dict[str, str]:
@@ -99,6 +107,11 @@ def require_api_key(request: Request) -> str | None:
     # Single-key mode.
     expected = _pilot_api_key()
     if not expected:
+        if _pilot_require_auth():
+            raise HTTPException(
+                status_code=503,
+                detail="Pilot API authentication is required but not configured.",
+            )
         request.state.user_id = DEFAULT_USER_ID
         return None
 

--- a/src/exa_demo/api_auth.py
+++ b/src/exa_demo/api_auth.py
@@ -64,7 +64,11 @@ def _pilot_users() -> dict[str, str]:
     try:
         mapping = json.loads(raw)
         if isinstance(mapping, dict):
-            return {str(k): str(v) for k, v in mapping.items()}
+            return {
+                str(k): v.strip()
+                for k, v in mapping.items()
+                if isinstance(v, str) and v.strip()
+            }
     except (json.JSONDecodeError, TypeError):
         logger.warning("PILOT_USERS is set but not valid JSON; ignoring")
     return {}

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -131,6 +131,47 @@ def test_auth_disabled_when_no_key(open_client):
     assert resp.status_code == 200
 
 
+def test_required_auth_without_config_fails_closed(_base_patches, monkeypatch):
+    monkeypatch.setenv("PILOT_REQUIRE_AUTH", "1")
+    client = TestClient(api_module.app)
+
+    resp = client.post("/api/search", json={"query": "test", "mode": "smoke"})
+
+    assert resp.status_code == 503
+    assert "authentication is required" in resp.json()["detail"]
+
+
+def test_required_auth_invalid_users_config_fails_closed(
+    _base_patches, monkeypatch
+):
+    monkeypatch.setenv("PILOT_REQUIRE_AUTH", "1")
+    monkeypatch.setenv("PILOT_USERS", "{not-json")
+    client = TestClient(api_module.app)
+
+    resp = client.post("/api/search", json={"query": "test", "mode": "smoke"})
+
+    assert resp.status_code == 503
+    assert "authentication is required" in resp.json()["detail"]
+
+
+def test_required_auth_preserves_configured_single_key_mode(
+    _base_patches, monkeypatch
+):
+    monkeypatch.setenv("PILOT_REQUIRE_AUTH", "1")
+    monkeypatch.setenv("PILOT_API_KEY", "test-secret")
+    client = TestClient(api_module.app)
+
+    missing = client.post("/api/search", json={"query": "test", "mode": "smoke"})
+    assert missing.status_code == 401
+
+    valid = client.post(
+        "/api/search",
+        json={"query": "test", "mode": "smoke"},
+        headers={"Authorization": "Bearer test-secret"},
+    )
+    assert valid.status_code == 200
+
+
 # ---------------------------------------------------------------------------
 # Rate limiting
 # ---------------------------------------------------------------------------

--- a/tests/test_api_auth.py
+++ b/tests/test_api_auth.py
@@ -154,6 +154,54 @@ def test_required_auth_invalid_users_config_fails_closed(
     assert "authentication is required" in resp.json()["detail"]
 
 
+@pytest.mark.parametrize(
+    "secret, token",
+    [
+        (None, "None"),
+        ("", "anything"),
+        ("   ", "anything"),
+        ({}, "{}"),
+        ([], "[]"),
+        (True, "True"),
+        (False, "False"),
+        (0, "0"),
+        (123, "123"),
+        (1.5, "1.5"),
+    ],
+)
+def test_required_auth_invalid_user_secrets_fail_closed(
+    _base_patches, monkeypatch, secret, token
+):
+    monkeypatch.setenv("PILOT_REQUIRE_AUTH", "1")
+    monkeypatch.setenv("PILOT_USERS", json.dumps({"alice": secret}))
+    client = TestClient(api_module.app)
+
+    resp = client.post(
+        "/api/search",
+        json={"query": "test", "mode": "smoke"},
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert resp.status_code == 503
+    assert "authentication is required" in resp.json()["detail"]
+
+
+def test_required_auth_valid_users_config_still_accepts_matching_secret(
+    _base_patches, monkeypatch
+):
+    monkeypatch.setenv("PILOT_REQUIRE_AUTH", "1")
+    monkeypatch.setenv("PILOT_USERS", json.dumps({"alice": "real-secret"}))
+    client = TestClient(api_module.app)
+
+    resp = client.post(
+        "/api/search",
+        json={"query": "test", "mode": "smoke"},
+        headers={"Authorization": "Bearer real-secret"},
+    )
+
+    assert resp.status_code == 200
+
+
 def test_required_auth_preserves_configured_single_key_mode(
     _base_patches, monkeypatch
 ):
@@ -163,6 +211,29 @@ def test_required_auth_preserves_configured_single_key_mode(
 
     missing = client.post("/api/search", json={"query": "test", "mode": "smoke"})
     assert missing.status_code == 401
+
+    valid = client.post(
+        "/api/search",
+        json={"query": "test", "mode": "smoke"},
+        headers={"Authorization": "Bearer test-secret"},
+    )
+    assert valid.status_code == 200
+
+
+def test_invalid_users_config_does_not_override_single_key_mode(
+    _base_patches, monkeypatch
+):
+    monkeypatch.setenv("PILOT_REQUIRE_AUTH", "1")
+    monkeypatch.setenv("PILOT_API_KEY", "test-secret")
+    monkeypatch.setenv("PILOT_USERS", json.dumps({"alice": None}))
+    client = TestClient(api_module.app)
+
+    invalid = client.post(
+        "/api/search",
+        json={"query": "test", "mode": "smoke"},
+        headers={"Authorization": "Bearer None"},
+    )
+    assert invalid.status_code == 401
 
     valid = client.post(
         "/api/search",


### PR DESCRIPTION
Closes #64

Summary:
- Adds PILOT_REQUIRE_AUTH=1 as a narrow pilot/deployment guard for authenticated /api routes.
- Fails closed with 503 when required auth is enabled but neither PILOT_API_KEY nor valid PILOT_USERS is configured.
- Preserves local smoke/no-auth behavior when PILOT_REQUIRE_AUTH is unset and auth config is absent, and preserves existing bearer/multi-user behavior when auth is configured.
- Updates .env.example and docs/security.md only for the new guard; no OAuth, SSO, persistence, infrastructure, or unrelated API behavior changes.

Validation:
- python -m ruff check .
- python -m pytest -q tests/test_api_auth.py tests/test_users.py tests/test_api.py tests/test_jobs.py